### PR TITLE
fix: resolve ruff format issues and document GitHub MCP usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,9 @@ When implementing or modifying MCP tools, follow these established patterns:
 
 ## GitHub Development Workflow
 
-このプロジェクトでは、機能追加やバグ修正において以下のGitHubワークフローを採用します：
+このプロジェクトでは、機能追加やバグ修正において以下のGitHubワークフローを採用します。
+
+**重要**: このプロジェクトではGitHub操作にGitHub MCPを使用します。Claude CodeがGitHub MCP (Model Context Protocol) を通じて、プルリクエストの作成、マージ、ワークフロー管理を自動化します。手動でGitHub CLIコマンドを実行する必要はありません。
 
 ### ブランチ戦略
 - **main**: 安定版リリースブランチ。常にデプロイ可能な状態を維持
@@ -190,24 +192,9 @@ When implementing or modifying MCP tools, follow these established patterns:
    ```bash
    # ブランチをプッシュ
    git push origin feature/add-new-api-endpoints
-   
-   # GitHub CLIを使用してPR作成（推奨）
-   gh pr create --title "feat: add token management API endpoints" --body "$(cat <<'EOF'
-   ## Summary
-   - Add 5 new token management API endpoints (list, create, update, revoke, delete)
-   - Add comprehensive test coverage with 8 new test cases  
-   - Update OpenAPI specification with new endpoint definitions
-   
-   ## Test plan
-   - [x] Unit tests pass (pytest -m unit)
-   - [x] Code quality checks pass (ruff check/format)
-   - [x] All existing tests still pass
-   - [ ] Manual testing with real Authlete API (integration test)
-   
-   🤖 Generated with [Claude Code](https://claude.ai/code)
-   EOF
-   )"
    ```
+   
+   **Note**: プルリクエストの作成にはGitHub MCPを使用します。Claude Codeが自動的にGitHub MCPを利用してPRを作成し、適切なタイトルと説明を設定します。手動でGitHub CLIコマンドを実行する必要はありません。
 
 5. **レビュープロセス**
    ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,10 @@ When implementing or modifying MCP tools, follow these established patterns:
    git push origin feature/add-new-api-endpoints
    ```
    
-   **Note**: プルリクエストの作成にはGitHub MCPを使用します。Claude Codeが自動的にGitHub MCPを利用してPRを作成し、適切なタイトルと説明を設定します。手動でGitHub CLIコマンドを実行する必要はありません。
+   **GitHub MCP使用**: プルリクエストの作成は`mcp__github__create_pull_request`ツールを使用します。Claude Codeが自動的に以下の処理を行います：
+   - `mcp__github__create_branch`: 新しいブランチ作成（必要に応じて）
+   - `mcp__github__create_pull_request`: 適切なタイトルと説明でPR作成
+   - `mcp__github__update_pull_request`: レビューワーの設定やラベル追加
 
 5. **レビュープロセス**
    ```bash
@@ -207,10 +210,14 @@ When implementing or modifying MCP tools, follow these established patterns:
    ```
 
 6. **マージ**
-   ```bash
-   # レビュー承認後、GitHubでSquash and Mergeを実行
-   # ブランチは自動削除される設定
+   **GitHub MCP使用**: マージは`mcp__github__merge_pull_request`ツールを使用します：
    ```
+   mcp__github__merge_pull_request:
+   - merge_method: "squash" (Squash and Merge)
+   - commit_title: 適切なコミットタイトル
+   - commit_message: 詳細なコミットメッセージ
+   ```
+   ブランチは自動削除される設定です。
 
 ### PR作成時のガイドライン
 
@@ -262,8 +269,7 @@ git pull origin main
 git checkout -b hotfix/critical-bug-description
 # 修正・テスト・コミット
 git push origin hotfix/critical-bug-description
-gh pr create --title "hotfix: critical bug description" --body "緊急修正の詳細"
-# 即座にマージ
+# GitHub MCPを使用してPR作成・マージ (Claude Codeが自動実行)
 ```
 
 ## YOU SHOULD DO

--- a/scripts/cleanup_test_services.py
+++ b/scripts/cleanup_test_services.py
@@ -36,7 +36,7 @@ async def delete_service_by_api_key(config: AuthleteConfig, service_api_key: str
             api_key=service_api_key,
             base_url=config.base_url,
             idp_url=config.idp_url,
-            api_server_id=config.api_server_id
+            api_server_id=config.api_server_id,
         )
 
         service_details = await make_authlete_request("GET", "service", service_config)
@@ -49,14 +49,14 @@ async def delete_service_by_api_key(config: AuthleteConfig, service_api_key: str
         # Delete using IdP API
         delete_data = {
             "organizationId": config.organization_id or os.getenv("ORGANIZATION_ID", ""),
-            "serviceId": service_id
+            "serviceId": service_id,
         }
 
         org_config = AuthleteConfig(
             api_key=config.api_key,  # Use organization token for IdP operations
             base_url=config.base_url,
             idp_url=config.idp_url,
-            api_server_id=config.api_server_id
+            api_server_id=config.api_server_id,
         )
 
         await make_authlete_idp_request("POST", "service/remove", org_config, delete_data)
@@ -83,19 +83,13 @@ async def cleanup_test_services():
         print("⚠️ ORGANIZATION_ID not set, using empty string")
 
     # Create config
-    config = AuthleteConfig(
-        api_key=org_token,
-        organization_id=organization_id
-    )
+    config = AuthleteConfig(api_key=org_token, organization_id=organization_id)
 
     # List all services
     services = await list_all_services(config)
 
     # Filter services that start with "pytest-"
-    test_services = [
-        service for service in services
-        if service.get("serviceName", "").startswith("pytest-")
-    ]
+    test_services = [service for service in services if service.get("serviceName", "").startswith("pytest-")]
 
     if not test_services:
         print("✅ No pytest services found to clean up")


### PR DESCRIPTION
## Summary
- Fix code formatting issues in scripts/cleanup_test_services.py that caused GitHub Actions to fail
- Update CLAUDE.md to document proper GitHub MCP tool usage instead of manual GitHub CLI commands
- Replace gh pr create/merge examples with GitHub MCP automation workflows

## Test plan
- [x] Unit tests pass (pytest -m unit)
- [x] Code quality checks pass (ruff check/format)
- [x] All existing tests still pass
- [x] GitHub Actions should now pass without format errors

## Changes
- **scripts/cleanup_test_services.py**: Applied ruff formatting (trailing commas, code style)
- **CLAUDE.md**: Updated workflow documentation to use GitHub MCP tools:
  - `mcp__github__create_pull_request` for PR creation
  - `mcp__github__merge_pull_request` for merging
  - Removed manual `gh pr create` commands

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>