### PR TITLE
feat: add JWKS generation tool using mkjwk.org API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,9 @@ uv run python scripts/update_openapi_spec.py  # Update resources/openapi-spec.js
 uv run python scripts/cleanup_test_services.py  # Delete services with "pytest-" prefix
 
 # Lint and format code
-ruff check src/ tests/ scripts/
-ruff format src/ tests/ scripts/
+uv run ruff check authlete_mcp_server.py tests/ scripts/    # Check for linting errors
+uv run ruff format authlete_mcp_server.py tests/ scripts/   # Auto-format files
+uv run ruff check --fix authlete_mcp_server.py tests/      # Auto-fix fixable errors
 
 # Lint YAML files
 uv run yamllint .github/                # Lint YAML files with yamllint
@@ -261,15 +262,21 @@ When implementing or modifying MCP tools, follow these established patterns:
 - **CI Workflow**: API互換性チェック、パフォーマンステスト、カバレッジ生成
 - **OpenAPI Spec Update**: 毎日自動でAuthlete仕様書をチェック・更新PR作成
 
-### Hotfix対応
-緊急バグ修正の場合は、以下の簡素化されたフローを使用：
+### CI/CD失敗時の対応
+
+GitHub Actionsでlintingやテストが失敗した場合の修正方法：
+
+#### Lintingエラーの修正
 ```bash
-git checkout main
-git pull origin main  
-git checkout -b hotfix/critical-bug-description
-# 修正・テスト・コミット
-git push origin hotfix/critical-bug-description
-# GitHub MCPを使用してPR作成・マージ (Claude Codeが自動実行)
+# エラーの確認
+uv run ruff check authlete_mcp_server.py tests/
+
+# 自動修正可能なエラーを修正
+uv run ruff check --fix authlete_mcp_server.py tests/
+
+# フォーマットの修正
+uv run ruff format authlete_mcp_server.py tests/
+
 ```
 
 ## YOU SHOULD DO

--- a/authlete_mcp_server.py
+++ b/authlete_mcp_server.py
@@ -795,5 +795,88 @@ async def update_client_lock(
         return f"Error updating client lock: {str(e)}"
 
 
+@mcp.tool()
+async def generate_jwks(
+    kty: str = "rsa",
+    size: int = 2048,
+    use: Optional[str] = None,
+    alg: Optional[str] = None,
+    kid: Optional[str] = None,
+    gen: str = "specified",
+    crv: Optional[str] = None,
+    x509: bool = False,
+    ctx: Context = None
+) -> str:
+    """Generate JSON Web Key Set (JWKS) using mkjwk.org API.
+    
+    This tool generates cryptographic keys in JWK/JWKS format for use in OAuth 2.0/OpenID Connect implementations.
+    
+    Args:
+        kty: Key type - "rsa", "ec", "oct", or "okp" (default: "rsa")
+        size: Key size in bits for RSA/oct keys (default: 2048, minimum 512, step 8)
+        use: Key use - "sig" (signature) or "enc" (encryption), affects available algorithms
+        alg: Algorithm for the key (e.g., "RS256", "ES256", "HS256", "EdDSA")
+             - RSA sig: RS256,RS384,RS512,PS256,PS384,PS512
+             - RSA enc: RSA1_5,RSA-OAEP,RSA-OAEP-256
+             - EC sig: ES256,ES384,ES512,ES256K
+             - EC enc: ECDH-ES,ECDH-ES+A128KW,ECDH-ES+A192KW,ECDH-ES+A256KW
+             - oct sig: HS256,HS384,HS512
+             - oct enc: A128KW,A192KW,A256KW,A128GCMKW,A192GCMKW,A256GCMKW,dir
+             - okp sig: EdDSA
+             - okp enc: ECDH-ES,ECDH-ES+A128KW,ECDH-ES+A192KW,ECDH-ES+A256KW
+        kid: Key ID (optional) - identifier for the key
+        gen: Key ID generation method - "specified" (use kid param), "sha256", "sha1", "date", "timestamp" (default: "specified")
+        crv: Curve for EC/OKP keys - EC: "P-256","P-384","P-521","secp256k1", OKP: "Ed25519","Ed448","X25519","X448"
+        x509: Generate X.509 certificate wrapper for RSA/EC keys (default: False)
+    
+    Returns:
+        JSON string containing generated keys with jwk, jwks, and pub (public key) fields
+    """
+    try:
+        # Build the request URL
+        url = f"https://mkjwk.org/jwk/{kty}"
+        params = {}
+        
+        # Add parameters if provided
+        if alg:
+            params["alg"] = alg
+        if use:
+            params["use"] = use
+        if kid and gen == "specified":
+            params["kid"] = kid
+        if gen != "specified":
+            params["gen"] = gen
+        
+        # Key type specific parameters
+        if kty in ["rsa", "ec"]:
+            params["x509"] = str(x509).lower()
+        
+        if kty in ["rsa", "oct"]:
+            params["size"] = str(size)
+            
+        if kty in ["ec", "okp"]:
+            if not crv:
+                return "Error: curve (crv) parameter is required for EC and OKP key types"
+            params["crv"] = crv
+        
+        # Make the request
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(url, params=params)
+            response.raise_for_status()
+            
+            # Return the JSON response
+            result = response.json()
+            return json.dumps(result, indent=2)
+            
+    except httpx.HTTPStatusError as e:
+        return f"Error: HTTP {e.response.status_code} - {e.response.text}"
+    except httpx.RequestError as e:
+        return f"Error: Request failed - {str(e)}"
+    except json.JSONDecodeError as e:
+        return f"Error: Invalid JSON response - {str(e)}"
+    except Exception as e:
+        return f"Error generating JWKS: {str(e)}"
+
+
 if __name__ == "__main__":
     mcp.run()

--- a/tests/test_jwks_generation.py
+++ b/tests/test_jwks_generation.py
@@ -1,0 +1,304 @@
+"""Tests for JWKS generation functionality."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+@pytest.mark.unit
+async def test_jwks_generation_tool_exists():
+    """Test that generate_jwks tool is available."""
+    server_params = StdioServerParameters(
+        command="uv", args=["run", "python", "authlete_mcp_server.py"], 
+        env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
+    )
+
+    async with stdio_client(server_params) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+
+            # List tools
+            tools = await session.list_tools()
+            tool_names = [tool.name for tool in tools.tools]
+            assert "generate_jwks" in tool_names
+
+            # Check tool schema
+            jwks_tool = next(tool for tool in tools.tools if tool.name == "generate_jwks")
+            assert jwks_tool.description
+            assert "JSON Web Key Set" in jwks_tool.description
+            assert "mkjwk.org" in jwks_tool.description
+
+
+@pytest.mark.integration
+async def test_generate_jwks_default_rsa():
+    """Test RSA key generation with default parameters."""
+    server_params = StdioServerParameters(
+        command="uv", args=["run", "python", "authlete_mcp_server.py"],
+        env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
+    )
+
+    async with stdio_client(server_params) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+
+            # Call generate_jwks tool with default parameters
+            result = await session.call_tool("generate_jwks", {})
+            assert result.content
+
+            response_text = result.content[0].text
+            data = json.loads(response_text)
+
+            # Verify structure
+            assert "jwk" in data
+            assert "jwks" in data
+            assert "pub" in data
+            assert data["jwk"]["kty"] == "RSA"
+            
+            # Verify RSA key components exist
+            jwk = data["jwk"]
+            assert "n" in jwk  # RSA modulus
+            assert "e" in jwk  # RSA exponent
+
+
+@pytest.mark.integration
+async def test_generate_jwks_ec_with_curve():
+    """Test EC key generation with curve parameter."""
+    server_params = StdioServerParameters(
+        command="uv", args=["run", "python", "authlete_mcp_server.py"],
+        env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
+    )
+
+    async with stdio_client(server_params) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+
+            # Call generate_jwks tool with EC parameters
+            result = await session.call_tool("generate_jwks", {
+                "kty": "ec",
+                "crv": "P-256",
+                "use": "sig",
+                "alg": "ES256"
+            })
+            assert result.content
+
+            response_text = result.content[0].text
+            data = json.loads(response_text)
+
+            assert data["jwk"]["kty"] == "EC"
+            assert data["jwk"]["crv"] == "P-256"
+            assert data["jwk"]["use"] == "sig"
+            assert data["jwk"]["alg"] == "ES256"
+            
+            # Verify EC key components exist
+            jwk = data["jwk"]
+            assert "x" in jwk  # EC x coordinate
+            assert "y" in jwk  # EC y coordinate
+
+
+@pytest.mark.unit
+async def test_generate_jwks_ec_missing_curve():
+    """Test EC key generation fails without curve parameter."""
+    server_params = StdioServerParameters(
+        command="uv", args=["run", "python", "authlete_mcp_server.py"],
+        env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
+    )
+
+    async with stdio_client(server_params) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+
+            # Call generate_jwks tool with EC but no curve
+            result = await session.call_tool("generate_jwks", {
+                "kty": "ec",
+                "use": "sig"
+            })
+            assert result.content
+
+            response_text = result.content[0].text
+            assert "Error: curve (crv) parameter is required" in response_text
+
+
+@pytest.mark.integration
+async def test_generate_jwks_with_x509():
+    """Test key generation with X.509 certificate."""
+    server_params = StdioServerParameters(
+        command="uv", args=["run", "python", "authlete_mcp_server.py"],
+        env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
+    )
+
+    async with stdio_client(server_params) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+
+            # Call generate_jwks tool with X.509
+            result = await session.call_tool("generate_jwks", {
+                "kty": "rsa",
+                "x509": True,
+                "size": 2048,
+                "use": "sig"
+            })
+            assert result.content
+
+            response_text = result.content[0].text
+            data = json.loads(response_text)
+
+            assert "cert" in data
+            assert "x509pub" in data
+            assert "x509priv" in data
+            
+            # Verify X.509 certificate format
+            assert data["cert"].startswith("-----BEGIN CERTIFICATE-----")
+            assert data["x509pub"].startswith("-----BEGIN PUBLIC KEY-----")
+            assert data["x509priv"].startswith("-----BEGIN PRIVATE KEY-----")
+
+
+@pytest.mark.integration
+async def test_generate_jwks_okp_with_curve():
+    """Test OKP key generation with Ed25519 curve."""
+    server_params = StdioServerParameters(
+        command="uv", args=["run", "python", "authlete_mcp_server.py"],
+        env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
+    )
+
+    async with stdio_client(server_params) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+
+            # Call generate_jwks tool with OKP parameters
+            result = await session.call_tool("generate_jwks", {
+                "kty": "okp",
+                "crv": "Ed25519",
+                "use": "sig",
+                "alg": "EdDSA"
+            })
+            assert result.content
+
+            response_text = result.content[0].text
+            data = json.loads(response_text)
+
+            assert data["jwk"]["kty"] == "OKP"
+            assert data["jwk"]["crv"] == "Ed25519"
+            assert data["jwk"]["use"] == "sig"
+            assert data["jwk"]["alg"] == "EdDSA"
+            
+            # Verify OKP key components exist
+            jwk = data["jwk"]
+            assert "x" in jwk  # OKP x coordinate
+
+
+@pytest.mark.integration
+async def test_generate_jwks_oct_with_size():
+    """Test oct (symmetric) key generation with custom size."""
+    server_params = StdioServerParameters(
+        command="uv", args=["run", "python", "authlete_mcp_server.py"],
+        env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
+    )
+
+    async with stdio_client(server_params) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+
+            # Call generate_jwks tool with oct parameters
+            result = await session.call_tool("generate_jwks", {
+                "kty": "oct",
+                "size": 256,
+                "use": "sig",
+                "alg": "HS256"
+            })
+            assert result.content
+
+            response_text = result.content[0].text
+            data = json.loads(response_text)
+
+            assert data["jwk"]["kty"] == "oct"
+            assert data["jwk"]["use"] == "sig"
+            assert data["jwk"]["alg"] == "HS256"
+            
+            # Verify oct key components exist
+            jwk = data["jwk"]
+            assert "k" in jwk  # Symmetric key value
+
+
+@pytest.mark.integration
+async def test_generate_jwks_with_kid_generation():
+    """Test key generation with automatic key ID generation."""
+    server_params = StdioServerParameters(
+        command="uv", args=["run", "python", "authlete_mcp_server.py"],
+        env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
+    )
+
+    async with stdio_client(server_params) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+
+            # Call generate_jwks tool with date generation
+            result = await session.call_tool("generate_jwks", {
+                "kty": "rsa",
+                "gen": "date"
+            })
+            assert result.content
+
+            response_text = result.content[0].text
+            data = json.loads(response_text)
+
+            assert "kid" in data["jwk"]
+            
+            # The key ID should be generated automatically
+            kid = data["jwk"]["kid"]
+            assert kid is not None
+            assert len(kid) > 0
+
+
+@pytest.mark.integration
+async def test_generate_jwks_real_api():
+    """Integration test with actual mkjwk.org API."""
+    server_params = StdioServerParameters(
+        command="uv", args=["run", "python", "authlete_mcp_server.py"],
+        env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
+    )
+
+    async with stdio_client(server_params) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+
+            # Call generate_jwks tool with real API
+            result = await session.call_tool("generate_jwks", {
+                "kty": "rsa",
+                "size": 2048,
+                "use": "sig",
+                "alg": "RS256"
+            })
+            assert result.content
+
+            response_text = result.content[0].text
+            data = json.loads(response_text)
+
+            # Verify structure
+            assert "jwk" in data
+            assert "jwks" in data
+            assert "pub" in data
+            
+            # Verify RSA key components
+            jwk = data["jwk"]
+            assert jwk["kty"] == "RSA"
+            assert jwk["use"] == "sig"
+            assert jwk["alg"] == "RS256"
+            assert "n" in jwk  # RSA modulus
+            assert "e" in jwk  # RSA exponent
+            assert "d" in jwk  # Private exponent (private key)
+            
+            # Verify JWKS structure
+            jwks = data["jwks"]
+            assert "keys" in jwks
+            assert len(jwks["keys"]) == 1
+            assert jwks["keys"][0]["kty"] == "RSA"
+            
+            # Verify public key doesn't have private components
+            pub = data["pub"]
+            assert pub["kty"] == "RSA"
+            assert "n" in pub
+            assert "e" in pub
+            assert "d" not in pub  # Should not have private exponent

--- a/tests/test_jwks_generation.py
+++ b/tests/test_jwks_generation.py
@@ -1,7 +1,6 @@
 """Tests for JWKS generation functionality."""
 
 import json
-from unittest.mock import AsyncMock, patch
 
 import pytest
 from mcp import ClientSession, StdioServerParameters
@@ -12,8 +11,7 @@ from mcp.client.stdio import stdio_client
 async def test_jwks_generation_tool_exists():
     """Test that generate_jwks tool is available."""
     server_params = StdioServerParameters(
-        command="uv", args=["run", "python", "authlete_mcp_server.py"], 
-        env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
+        command="uv", args=["run", "python", "authlete_mcp_server.py"], env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
     )
 
     async with stdio_client(server_params) as (read_stream, write_stream):
@@ -36,8 +34,7 @@ async def test_jwks_generation_tool_exists():
 async def test_generate_jwks_default_rsa():
     """Test RSA key generation with default parameters."""
     server_params = StdioServerParameters(
-        command="uv", args=["run", "python", "authlete_mcp_server.py"],
-        env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
+        command="uv", args=["run", "python", "authlete_mcp_server.py"], env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
     )
 
     async with stdio_client(server_params) as (read_stream, write_stream):
@@ -56,7 +53,7 @@ async def test_generate_jwks_default_rsa():
             assert "jwks" in data
             assert "pub" in data
             assert data["jwk"]["kty"] == "RSA"
-            
+
             # Verify RSA key components exist
             jwk = data["jwk"]
             assert "n" in jwk  # RSA modulus
@@ -67,8 +64,7 @@ async def test_generate_jwks_default_rsa():
 async def test_generate_jwks_ec_with_curve():
     """Test EC key generation with curve parameter."""
     server_params = StdioServerParameters(
-        command="uv", args=["run", "python", "authlete_mcp_server.py"],
-        env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
+        command="uv", args=["run", "python", "authlete_mcp_server.py"], env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
     )
 
     async with stdio_client(server_params) as (read_stream, write_stream):
@@ -76,12 +72,9 @@ async def test_generate_jwks_ec_with_curve():
             await session.initialize()
 
             # Call generate_jwks tool with EC parameters
-            result = await session.call_tool("generate_jwks", {
-                "kty": "ec",
-                "crv": "P-256",
-                "use": "sig",
-                "alg": "ES256"
-            })
+            result = await session.call_tool(
+                "generate_jwks", {"kty": "ec", "crv": "P-256", "use": "sig", "alg": "ES256"}
+            )
             assert result.content
 
             response_text = result.content[0].text
@@ -91,7 +84,7 @@ async def test_generate_jwks_ec_with_curve():
             assert data["jwk"]["crv"] == "P-256"
             assert data["jwk"]["use"] == "sig"
             assert data["jwk"]["alg"] == "ES256"
-            
+
             # Verify EC key components exist
             jwk = data["jwk"]
             assert "x" in jwk  # EC x coordinate
@@ -102,8 +95,7 @@ async def test_generate_jwks_ec_with_curve():
 async def test_generate_jwks_ec_missing_curve():
     """Test EC key generation fails without curve parameter."""
     server_params = StdioServerParameters(
-        command="uv", args=["run", "python", "authlete_mcp_server.py"],
-        env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
+        command="uv", args=["run", "python", "authlete_mcp_server.py"], env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
     )
 
     async with stdio_client(server_params) as (read_stream, write_stream):
@@ -111,10 +103,7 @@ async def test_generate_jwks_ec_missing_curve():
             await session.initialize()
 
             # Call generate_jwks tool with EC but no curve
-            result = await session.call_tool("generate_jwks", {
-                "kty": "ec",
-                "use": "sig"
-            })
+            result = await session.call_tool("generate_jwks", {"kty": "ec", "use": "sig"})
             assert result.content
 
             response_text = result.content[0].text
@@ -125,8 +114,7 @@ async def test_generate_jwks_ec_missing_curve():
 async def test_generate_jwks_with_x509():
     """Test key generation with X.509 certificate."""
     server_params = StdioServerParameters(
-        command="uv", args=["run", "python", "authlete_mcp_server.py"],
-        env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
+        command="uv", args=["run", "python", "authlete_mcp_server.py"], env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
     )
 
     async with stdio_client(server_params) as (read_stream, write_stream):
@@ -134,12 +122,7 @@ async def test_generate_jwks_with_x509():
             await session.initialize()
 
             # Call generate_jwks tool with X.509
-            result = await session.call_tool("generate_jwks", {
-                "kty": "rsa",
-                "x509": True,
-                "size": 2048,
-                "use": "sig"
-            })
+            result = await session.call_tool("generate_jwks", {"kty": "rsa", "x509": True, "size": 2048, "use": "sig"})
             assert result.content
 
             response_text = result.content[0].text
@@ -148,7 +131,7 @@ async def test_generate_jwks_with_x509():
             assert "cert" in data
             assert "x509pub" in data
             assert "x509priv" in data
-            
+
             # Verify X.509 certificate format
             assert data["cert"].startswith("-----BEGIN CERTIFICATE-----")
             assert data["x509pub"].startswith("-----BEGIN PUBLIC KEY-----")
@@ -159,8 +142,7 @@ async def test_generate_jwks_with_x509():
 async def test_generate_jwks_okp_with_curve():
     """Test OKP key generation with Ed25519 curve."""
     server_params = StdioServerParameters(
-        command="uv", args=["run", "python", "authlete_mcp_server.py"],
-        env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
+        command="uv", args=["run", "python", "authlete_mcp_server.py"], env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
     )
 
     async with stdio_client(server_params) as (read_stream, write_stream):
@@ -168,12 +150,9 @@ async def test_generate_jwks_okp_with_curve():
             await session.initialize()
 
             # Call generate_jwks tool with OKP parameters
-            result = await session.call_tool("generate_jwks", {
-                "kty": "okp",
-                "crv": "Ed25519",
-                "use": "sig",
-                "alg": "EdDSA"
-            })
+            result = await session.call_tool(
+                "generate_jwks", {"kty": "okp", "crv": "Ed25519", "use": "sig", "alg": "EdDSA"}
+            )
             assert result.content
 
             response_text = result.content[0].text
@@ -183,7 +162,7 @@ async def test_generate_jwks_okp_with_curve():
             assert data["jwk"]["crv"] == "Ed25519"
             assert data["jwk"]["use"] == "sig"
             assert data["jwk"]["alg"] == "EdDSA"
-            
+
             # Verify OKP key components exist
             jwk = data["jwk"]
             assert "x" in jwk  # OKP x coordinate
@@ -193,8 +172,7 @@ async def test_generate_jwks_okp_with_curve():
 async def test_generate_jwks_oct_with_size():
     """Test oct (symmetric) key generation with custom size."""
     server_params = StdioServerParameters(
-        command="uv", args=["run", "python", "authlete_mcp_server.py"],
-        env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
+        command="uv", args=["run", "python", "authlete_mcp_server.py"], env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
     )
 
     async with stdio_client(server_params) as (read_stream, write_stream):
@@ -202,12 +180,7 @@ async def test_generate_jwks_oct_with_size():
             await session.initialize()
 
             # Call generate_jwks tool with oct parameters
-            result = await session.call_tool("generate_jwks", {
-                "kty": "oct",
-                "size": 256,
-                "use": "sig",
-                "alg": "HS256"
-            })
+            result = await session.call_tool("generate_jwks", {"kty": "oct", "size": 256, "use": "sig", "alg": "HS256"})
             assert result.content
 
             response_text = result.content[0].text
@@ -216,7 +189,7 @@ async def test_generate_jwks_oct_with_size():
             assert data["jwk"]["kty"] == "oct"
             assert data["jwk"]["use"] == "sig"
             assert data["jwk"]["alg"] == "HS256"
-            
+
             # Verify oct key components exist
             jwk = data["jwk"]
             assert "k" in jwk  # Symmetric key value
@@ -226,8 +199,7 @@ async def test_generate_jwks_oct_with_size():
 async def test_generate_jwks_with_kid_generation():
     """Test key generation with automatic key ID generation."""
     server_params = StdioServerParameters(
-        command="uv", args=["run", "python", "authlete_mcp_server.py"],
-        env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
+        command="uv", args=["run", "python", "authlete_mcp_server.py"], env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
     )
 
     async with stdio_client(server_params) as (read_stream, write_stream):
@@ -235,17 +207,14 @@ async def test_generate_jwks_with_kid_generation():
             await session.initialize()
 
             # Call generate_jwks tool with date generation
-            result = await session.call_tool("generate_jwks", {
-                "kty": "rsa",
-                "gen": "date"
-            })
+            result = await session.call_tool("generate_jwks", {"kty": "rsa", "gen": "date"})
             assert result.content
 
             response_text = result.content[0].text
             data = json.loads(response_text)
 
             assert "kid" in data["jwk"]
-            
+
             # The key ID should be generated automatically
             kid = data["jwk"]["kid"]
             assert kid is not None
@@ -256,8 +225,7 @@ async def test_generate_jwks_with_kid_generation():
 async def test_generate_jwks_real_api():
     """Integration test with actual mkjwk.org API."""
     server_params = StdioServerParameters(
-        command="uv", args=["run", "python", "authlete_mcp_server.py"],
-        env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
+        command="uv", args=["run", "python", "authlete_mcp_server.py"], env={"ORGANIZATION_ACCESS_TOKEN": "test-token"}
     )
 
     async with stdio_client(server_params) as (read_stream, write_stream):
@@ -265,12 +233,9 @@ async def test_generate_jwks_real_api():
             await session.initialize()
 
             # Call generate_jwks tool with real API
-            result = await session.call_tool("generate_jwks", {
-                "kty": "rsa",
-                "size": 2048,
-                "use": "sig",
-                "alg": "RS256"
-            })
+            result = await session.call_tool(
+                "generate_jwks", {"kty": "rsa", "size": 2048, "use": "sig", "alg": "RS256"}
+            )
             assert result.content
 
             response_text = result.content[0].text
@@ -280,7 +245,7 @@ async def test_generate_jwks_real_api():
             assert "jwk" in data
             assert "jwks" in data
             assert "pub" in data
-            
+
             # Verify RSA key components
             jwk = data["jwk"]
             assert jwk["kty"] == "RSA"
@@ -289,13 +254,13 @@ async def test_generate_jwks_real_api():
             assert "n" in jwk  # RSA modulus
             assert "e" in jwk  # RSA exponent
             assert "d" in jwk  # Private exponent (private key)
-            
+
             # Verify JWKS structure
             jwks = data["jwks"]
             assert "keys" in jwks
             assert len(jwks["keys"]) == 1
             assert jwks["keys"][0]["kty"] == "RSA"
-            
+
             # Verify public key doesn't have private components
             pub = data["pub"]
             assert pub["kty"] == "RSA"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Add `generate_jwks` tool to create JSON Web Key Sets for OAuth 2.0/OpenID Connect implementations
- Integration with mkjwk.org API for secure cryptographic key generation
- Support for all major key types: RSA, EC, oct (symmetric), and OKP (Edwards curve)
- Configurable parameters for key size, algorithms, curves, and Key ID generation
- X.509 certificate generation support for RSA and EC keys

## Test plan
- [x] Unit tests pass (pytest -m unit) - 2 tests covering tool availability and error handling
- [x] Integration tests pass (pytest -m integration) - 7 tests with real mkjwk.org API calls
- [x] Code quality checks pass (ruff check/format)
- [x] Manual testing completed - verified key generation for all supported key types

## Key Features
- **Key Types**: RSA (default), EC, oct, OKP with appropriate parameter validation
- **Algorithms**: Full support for signature and encryption algorithms per key type
- **Key ID Generation**: SHA256/SHA1 hashing, date/timestamp, or custom values
- **X.509 Support**: Certificate wrapper generation for RSA and EC keys
- **Error Handling**: Comprehensive error handling for API failures and invalid parameters

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)