### PR TITLE
fix: remove anyOf constraints from MCP tool schemas to resolve Claude Desktop compatibility

### DIFF
--- a/authlete_api_search_server.py
+++ b/authlete_api_search_server.py
@@ -416,7 +416,7 @@ async def handle_list_tools() -> list[Tool]:
         ),
         Tool(
             name="get_api_detail",
-            description="Get detailed information for specific API (parameters, request/response, sample code)",
+            description="Get detailed information for specific API (parameters, request/response, sample code). Provide either operation_id OR both path and method.",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -428,12 +428,11 @@ async def handle_list_tools() -> list[Tool]:
                         "description": "Sample code language (curl, javascript, python, java, etc.)",
                     },
                 },
-                "anyOf": [{"required": ["path", "method"]}, {"required": ["operation_id"]}],
             },
         ),
         Tool(
             name="get_sample_code",
-            description="Get sample code for specific API in specified language",
+            description="Get sample code for specific API in specified language. Provide language and either operation_id OR both path and method.",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -443,7 +442,6 @@ async def handle_list_tools() -> list[Tool]:
                     "language": {"type": "string", "description": "Programming language"},
                 },
                 "required": ["language"],
-                "anyOf": [{"required": ["path", "method", "language"]}, {"required": ["operation_id", "language"]}],
             },
         ),
     ]


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- `get_api_detail` と `get_sample_code` ツールスキーマから `anyOf` 制約を削除
- Claude Desktop MCP クライアントがトップレベルでの oneOf/allOf/anyOf をサポートしていないため互換性エラーが発生していた問題を修正
- ツール説明文でパラメータ要件を明確化
- バリデーションロジックはコード内で維持

## Test plan
- [x] スキーマ修正でエラーが解消されることを確認
- [x] 既存の機能が正常に動作することを確認
- [x] MCP サーバーが正常に起動することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)