### PR TITLE
feat: add schema search functionality to API documentation search

### DIFF
--- a/scripts/create_search_database.py
+++ b/scripts/create_search_database.py
@@ -36,6 +36,7 @@ class OpenAPISearchDatabase:
 
         # まず、既存のテーブルがあれば削除
         self.conn.execute("DROP TABLE IF EXISTS api_endpoints")
+        self.conn.execute("DROP TABLE IF EXISTS api_schemas")
 
         # API エンドポイント用のテーブル作成
         self.conn.execute("""
@@ -57,6 +58,23 @@ class OpenAPISearchDatabase:
             )
         """)
 
+        # API スキーマ用のテーブル作成
+        self.conn.execute("CREATE SEQUENCE IF NOT EXISTS api_schemas_seq START 1")
+        self.conn.execute("""
+            CREATE TABLE api_schemas (
+                id INTEGER PRIMARY KEY DEFAULT nextval('api_schemas_seq'),
+                schema_name VARCHAR NOT NULL,
+                schema_type VARCHAR, -- object, array, string, etc.
+                title VARCHAR,
+                description TEXT,
+                properties TEXT, -- JSON properties as text
+                required_fields VARCHAR[], -- Array of required field names
+                example_value TEXT, -- JSON example
+                search_content TEXT NOT NULL, -- Combined searchable text
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
         # FTSインデックスの作成 (BM25対応)
         logger.info("FTSインデックスを作成中...")
 
@@ -69,6 +87,15 @@ class OpenAPISearchDatabase:
             self.conn.execute("""
                 PRAGMA create_fts_index(
                     'api_endpoints',
+                    'id',
+                    'search_content'
+                )
+            """)
+
+            # スキーマテーブル用のFTSインデックス作成
+            self.conn.execute("""
+                PRAGMA create_fts_index(
+                    'api_schemas',
                     'id',
                     'search_content'
                 )
@@ -332,6 +359,126 @@ class OpenAPISearchDatabase:
                 logger.info("  検索結果なし")
             logger.info("")
 
+    def extract_schema_data(self, openapi_spec_path: str) -> list[dict[str, Any]]:
+        """OpenAPI仕様書からスキーマ情報を抽出
+
+        Args:
+            openapi_spec_path: OpenAPI仕様書のパス
+
+        Returns:
+            スキーマ情報のリスト
+        """
+        with open(openapi_spec_path, encoding="utf-8") as f:
+            spec = json.load(f)
+
+        # $refを解決
+        spec = jsonref.loads(json.dumps(spec))
+
+        schemas_data = []
+
+        # components.schemasを抽出
+        components = spec.get("components", {})
+        schemas = components.get("schemas", {})
+
+        for schema_name, schema_def in schemas.items():
+            if not isinstance(schema_def, dict):
+                continue
+
+            schema_type = schema_def.get("type", "object")
+            title = schema_def.get("title", "")
+            description = schema_def.get("description", "")
+
+            # プロパティを文字列として保存
+            try:
+                properties_data = schema_def.get("properties", {})
+                # 循環参照や複雑なオブジェクトを処理するため、defaultオプションを使用
+                properties = json.dumps(properties_data, ensure_ascii=False, default=str)
+            except (TypeError, ValueError) as e:
+                logger.warning(f"スキーマ {schema_name} のプロパティをJSONシリアライズできません: {e}")
+                properties = "{}"
+
+            # 必須フィールドの抽出（JSON文字列として保存）
+            required_fields = schema_def.get("required", [])
+
+            # サンプル値の抽出
+            example_value = ""
+            if "example" in schema_def:
+                try:
+                    example_value = json.dumps(schema_def["example"], ensure_ascii=False, default=str)
+                except (TypeError, ValueError) as e:
+                    logger.warning(f"スキーマ {schema_name} のexample値をJSONシリアライズできません: {e}")
+                    example_value = str(schema_def["example"])
+
+            # 検索用コンテンツの作成
+            search_parts = [
+                schema_name,
+                title,
+                description,
+                schema_type,
+            ]
+
+            # プロパティ名も検索対象に追加
+            if "properties" in schema_def:
+                for prop_name, prop_def in schema_def["properties"].items():
+                    search_parts.append(prop_name)
+                    if isinstance(prop_def, dict) and "description" in prop_def:
+                        search_parts.append(prop_def["description"])
+
+            search_content = " ".join(filter(None, search_parts))
+
+            schema_data = {
+                "schema_name": schema_name,
+                "schema_type": schema_type,
+                "title": title,
+                "description": description,
+                "properties": properties,
+                "required_fields": required_fields,
+                "example_value": example_value,
+                "search_content": search_content,
+            }
+
+            schemas_data.append(schema_data)
+
+        logger.info(f"抽出されたスキーマ数: {len(schemas_data)}")
+        return schemas_data
+
+    def insert_schema_data(self, schemas_data: list[dict[str, Any]]) -> None:
+        """スキーマデータをデータベースに挿入
+
+        Args:
+            schemas_data: スキーマデータのリスト
+        """
+        logger.info(f"スキーマデータを挿入中... ({len(schemas_data)}件)")
+
+        for i, schema in enumerate(schemas_data, 1):
+            try:
+                self.conn.execute(
+                    """
+                    INSERT INTO api_schemas (
+                        schema_name, schema_type, title, description,
+                        properties, required_fields, example_value, search_content
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                    (
+                        schema["schema_name"],
+                        schema["schema_type"],
+                        schema["title"],
+                        schema["description"],
+                        schema["properties"],
+                        schema["required_fields"],  # Python list -> DuckDB VARCHAR[]
+                        schema["example_value"],
+                        schema["search_content"],
+                    ),
+                )
+
+                if i % 100 == 0:
+                    logger.info(f"  挿入済み: {i}/{len(schemas_data)}")
+
+            except Exception as e:
+                logger.error(f"スキーマデータ挿入エラー ({schema['schema_name']}): {str(e)}")
+
+        logger.info("スキーマデータ挿入完了")
+
     def get_database_stats(self) -> dict[str, Any]:
         """データベースの統計情報を取得"""
         stats = {}
@@ -339,6 +486,13 @@ class OpenAPISearchDatabase:
         # テーブルの行数
         result = self.conn.execute("SELECT COUNT(*) FROM api_endpoints").fetchone()
         stats["total_apis"] = result[0] if result else 0
+
+        # スキーマテーブルの行数
+        try:
+            result = self.conn.execute("SELECT COUNT(*) FROM api_schemas").fetchone()
+            stats["total_schemas"] = result[0] if result else 0
+        except Exception:
+            stats["total_schemas"] = 0
 
         # メソッド別統計
         result = self.conn.execute("""
@@ -397,6 +551,13 @@ def main():
 
         db.insert_api_data(api_data)
 
+        # スキーマデータの抽出と挿入
+        schema_data = db.extract_schema_data(openapi_spec_path)
+        if not schema_data:
+            logger.warning("スキーマデータが抽出できませんでした")
+        else:
+            db.insert_schema_data(schema_data)
+
         # 最適化
         db.optimize_database()
 
@@ -404,6 +565,7 @@ def main():
         stats = db.get_database_stats()
         logger.info("データベース統計:")
         logger.info(f"  総API数: {stats['total_apis']}")
+        logger.info(f"  総スキーマ数: {stats['total_schemas']}")
         logger.info(f"  HTTPメソッド別: {stats['methods']}")
         logger.info(f"  主要タグ: {stats['top_tags']}")
         logger.info(f"  DBサイズ: {stats['database_size_mb']:.2f} MB")


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Add `list_schemas` MCP tool to list and search OpenAPI schemas with natural language queries
- Add `get_schema_detail` MCP tool to retrieve detailed schema information including properties, required fields, and examples
- Extend `AuthleteApiSearcher` class with `search_schemas()` and `get_schema_detail()` methods
- Update search database creation to properly extract and store schema data with improved JSON serialization
- Add comprehensive test suite covering both unit and integration tests for schema search functionality
- Support natural language search queries and type filtering for schemas (object, array, string, etc.)
- Include 33 OpenAPI schemas extracted from Authlete API documentation

## Test plan
- [x] Unit tests pass (pytest -m unit) - All 35 unit tests passing
- [x] Integration tests pass (pytest -m integration) - Schema search integration tests included  
- [x] Code quality checks pass (ruff check/format) - All linting and formatting checks passing
- [x] Manual testing completed - Verified schema search and detail retrieval functionality
- [x] Database validation - Confirmed 33 schemas properly extracted with properties and metadata

## Key Features
- **Schema Discovery**: List all available OpenAPI schemas or search by name/description
- **Detailed Schema Information**: Get comprehensive schema details including 96+ properties for complex schemas like `Client`
- **Natural Language Search**: Search schemas using queries like "token" to find relevant schemas
- **Type Filtering**: Filter schemas by type (object, array, string, etc.)
- **Full-Text Search**: Leverage existing FTS capabilities for fast schema discovery
- **Comprehensive Coverage**: All 33 Authlete API schemas available for exploration

The schema search functionality complements the existing API search by providing access to OpenAPI schema definitions, enabling developers to better understand the data structures used throughout the Authlete API.

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)