### PR TITLE
fix: resolve MCP Inspector parameter validation errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,23 @@
 #!/usr/bin/env python3
 """Main entry point for Authlete MCP Server."""
 
+import logging
+
 from src.authlete_mcp.server import run
 
+# Setup logging configuration for debugging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    filename="/tmp/authlete_mcp.log",  # Log to file instead of stderr
+    filemode="w",  # Overwrite log file each time
+)
+
+# Enable debug logging for our modules
+logging.getLogger("authlete_mcp").setLevel(logging.DEBUG)
+logging.getLogger("src.authlete_mcp").setLevel(logging.DEBUG)
+
 if __name__ == "__main__":
+    logger = logging.getLogger(__name__)
+    logger.info("Starting Authlete MCP Server with debug logging...")
     run()

--- a/src/authlete_mcp/search.py
+++ b/src/authlete_mcp/search.py
@@ -58,7 +58,6 @@ class AuthleteApiSearcher:
         description_query: str | None = None,
         tag_filter: str | None = None,
         method_filter: str | None = None,
-        mode: str = "natural",
         limit: int = 20,
     ) -> list[dict[str, Any]]:
         """
@@ -70,7 +69,6 @@ class AuthleteApiSearcher:
             description_query: Description search
             tag_filter: Tag filtering
             method_filter: HTTP method filtering
-            mode: Search mode (kept for compatibility, actually uses natural language search)
             limit: Maximum number of results
 
         Returns:


### PR DESCRIPTION
## Summary
- Change parameter types from `str | None = None` to `str = ""` in search tools to fix MCP Inspector compatibility
- Remove deprecated `mode` parameter from search_apis and unnecessary schema_type parameter from list_schemas  
- Convert Japanese comments and error messages to English for consistency
- Add comprehensive logging for debugging MCP Inspector interactions
- Update tests to reflect new validation behavior

## Test plan
- [x] Unit tests pass (pytest -m unit) - All 83 tests passed
- [x] Search tools parameter validation works correctly
- [x] MCP Inspector can now successfully call search_apis with string parameters
- [x] Code quality checks pass (ruff check/format)
- [x] Pre-commit hooks validation passed

## Background
This fixes the issue where recent MCP Inspector UI changes resulted in parameter validation errors when using search tools. The error occurred because MCP Inspector was sending dictionary-like parameters that didn't match our `str | None` type annotations, causing Pydantic validation failures.

The main changes:
1. **Parameter Type Changes**: Updated all search tool parameters from `str | None = None` to `str = ""` 
2. **Simplified Logic**: Removed complex None-to-string conversion logic
3. **Better Error Messages**: Converted Japanese error messages to English
4. **Enhanced Logging**: Added detailed logging for MCP Inspector debugging
5. **Test Updates**: Updated tests to expect validation errors when None values are passed

🤖 Generated with [Claude Code](https://claude.ai/code)