### PR TITLE
fix: update pre-commit hooks to run unit tests only

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -85,10 +85,10 @@ fi
 
 # 4. Unit Tests
 print_status "Running unit tests..."
-if uv run pytest tests/ -x -q; then
-    print_success "All tests passed"
+if uv run pytest tests/ -x -q -m unit; then
+    print_success "All unit tests passed"
 else
-    print_error "Tests failed. Fix failing tests before committing."
+    print_error "Unit tests failed. Fix failing tests before committing."
     exit 1
 fi
 

--- a/setup-hooks.sh
+++ b/setup-hooks.sh
@@ -37,7 +37,7 @@ if .git/hooks/pre-commit; then
     echo "   • Code formatting (ruff)"
     echo "   • YAML validation"
     echo "   • Type checking (if mypy available)"
-    echo "   • Unit tests"
+    echo "   • Unit tests only (integration tests excluded to reduce server load)"
     echo "   • Database creation test"
     echo ""
     echo "💡 To bypass hooks temporarily, use: git commit --no-verify"


### PR DESCRIPTION
## Summary
- Pre-commitフックでユニットテストのみ実行するように変更
- サーバーへの負荷を軽減するためインテグレーションテストを除外
- GitHub Actionsではすべてのテストが引き続き実行される

## Changes
- `.githooks/pre-commit`: `pytest -m unit` フラグを追加してユニットテストのみ実行
- `setup-hooks.sh`: インテグレーションテストが除外されることを明記

## Test plan
- [x] Unit tests pass (pytest -m unit)  
- [x] Pre-commit hook works correctly with unit tests only
- [x] Code quality checks pass (ruff check/format)

🤖 Generated with [Claude Code](https://claude.ai/code)