### PR TITLE
chore: organize coverage files to dedicated directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+coverage/
 
 # Translations
 *.mo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,10 +82,17 @@ line-ending = "auto"
 source = ["src"]
 concurrency = ["multiprocessing"]
 parallel = true
+data_file = "./coverage/.coverage"
 omit = [
     "*/tests/*",
     "*/test_*",
     "*/conftest.py",
+]
+
+[tool.coverage.paths]
+source = [
+    "src/",
+    "*/site-packages/",
 ]
 
 [tool.coverage.report]
@@ -96,3 +103,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "if __name__ == .__main__.:",
 ]
+
+[tool.coverage.html]
+directory = "coverage/htmlcov"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Configure coverage data file output to `./coverage/.coverage`
- Set HTML coverage report output to `coverage/htmlcov/`
- Add `coverage/` directory to `.gitignore`
- Keep root directory clean from `.coverage.*` files

## Test plan
- [x] Unit tests pass (pytest -m unit)
- [x] Code quality checks pass (ruff check/format)
- [x] Coverage files are properly organized in coverage/ directory
- [x] Root directory remains clean during test execution

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)