### PR TITLE
perf: optimize Docker container startup time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,5 +34,5 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD python -c "import sys; sys.exit(0)"
 
-# Run the MCP server
-CMD ["uv", "run", "python", "main.py"]
+# Run the MCP server using the installed virtual environment
+CMD [".venv/bin/python", "main.py"]


### PR DESCRIPTION
## Summary
- Replace `uv run python main.py` with `.venv/bin/python main.py` in Dockerfile CMD
- Eliminates unnecessary dependency resolution and package downloads at container startup
- Uses pre-installed virtual environment directly for faster startup

## Test plan
- [x] Docker build completes successfully
- [x] Container starts without downloading additional packages
- [x] Unit tests pass
- [x] Pre-commit hooks pass
- [x] Manual startup test confirms no package downloads occur

## Performance Impact
**Before**: Container startup triggered `uv run` which downloaded packages (ruff, setuptools, pygments, etc.)
**After**: Container starts immediately using pre-installed `.venv/bin/python`

This resolves the issue where `docker run --rm -i ghcr.io/watahani/authlete-mcp:latest` was downloading packages at runtime instead of using the pre-built environment.

🤖 Generated with [Claude Code](https://claude.ai/code)