### PR TITLE
fix: resolve Docker security scan permissions issue

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -184,8 +184,35 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
 
+      - name: Display Trivy scan results
+        if: always()
+        run: |
+          echo "## Security Scan Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -f trivy-results.sarif ]; then
+            echo "✅ Trivy vulnerability scan completed successfully" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**SARIF file generated**: \`trivy-results.sarif\`" >> $GITHUB_STEP_SUMMARY
+            
+            # Run Trivy again in table format for summary display
+            docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
+              -v $(pwd):/workspace aquasec/trivy:latest image \
+              --format table --exit-code 0 authlete-mcp:scan >> trivy-summary.txt 2>&1 || true
+            
+            if [ -f trivy-summary.txt ]; then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "### Vulnerability Summary:" >> $GITHUB_STEP_SUMMARY
+              echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+              head -50 trivy-summary.txt >> $GITHUB_STEP_SUMMARY
+              echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            fi
+          else
+            echo "❌ SARIF file not found" >> $GITHUB_STEP_SUMMARY
+          fi
+
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
-        if: always()
+        # Only upload SARIF in main branch pushes due to security-events permission requirements
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -193,12 +193,11 @@ jobs:
             echo "✅ Trivy vulnerability scan completed successfully" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**SARIF file generated**: \`trivy-results.sarif\`" >> $GITHUB_STEP_SUMMARY
-            
+
             # Run Trivy again in table format for summary display
             docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
               -v $(pwd):/workspace aquasec/trivy:latest image \
               --format table --exit-code 0 authlete-mcp:scan >> trivy-summary.txt 2>&1 || true
-            
             if [ -f trivy-summary.txt ]; then
               echo "" >> $GITHUB_STEP_SUMMARY
               echo "### Vulnerability Summary:" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Fix `security-events: write` permission error in PR workflows
- Limit SARIF upload to main branch pushes only
- Add vulnerability scan summary display for PR visibility

## Changes
- **SARIF Upload**: Only execute on main branch pushes due to security-events permission requirements
- **PR Visibility**: Add step summary with vulnerability scan results for pull requests
- **Main Branch**: Continue uploading SARIF to GitHub Security tab for main branch pushes

## Test plan
- [x] YAML linting passes
- [x] Workflow syntax is valid
- [x] Security scan step will show results in PR summary
- [x] SARIF upload conditional logic prevents permission errors in PRs

## Problem Solved
Previously, PRs would fail with:
```
Error: Resource not accessible by integration (github/codeql-action/upload-sarif)
```

Now:
- **PRs**: Security scan runs and shows results in step summary (no SARIF upload)
- **Main branch**: Security scan runs and uploads SARIF to Security tab

🤖 Generated with [Claude Code](https://claude.ai/code)