### PR TITLE
fix: change search_apis default limit from 20 to 5

### DIFF
--- a/src/authlete_mcp/tools/search_tools.py
+++ b/src/authlete_mcp/tools/search_tools.py
@@ -17,7 +17,7 @@ async def search_apis(
     description_query: str = "",
     tag_filter: str = "",
     method_filter: str = "",
-    limit: int = 20,
+    limit: int = 5,
     ctx: Context = None,
 ) -> str:
     """Natural language API search. Semantic matching like 'revoke token' → 'This API revokes access tokens'. Returns description truncated to ~100 chars. Use get_api_detail for full information.
@@ -34,7 +34,7 @@ async def search_apis(
         description_query: Description search (e.g., 'revokes access tokens')
         tag_filter: Tag filter (e.g., 'Token Operations', 'Authorization') - applies to query and description_query
         method_filter: HTTP method filter (GET, POST, PUT, DELETE) - applies to all search types
-        limit: Maximum number of results (default: 20, max: 100)
+        limit: Maximum number of results (default: 5, max: 100)
     """
 
     try:
@@ -46,7 +46,7 @@ async def search_apis(
 
         # Validate limit
         if limit < 1 or limit > 100:
-            limit = 20
+            limit = 5
 
         # Check which search will be executed
         if query and query.strip():


### PR DESCRIPTION
## Summary
- search_apis関数のlimitデフォルト値を20から5に変更
- docstringのデフォルト値説明を更新
- バリデーション時のフォールバック値も新しいデフォルト値に更新

## Test plan
- [x] Unit tests pass (pytest -m unit)
- [x] Code quality checks pass (ruff check/format)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)