### PR TITLE
fix: add security-events permission for Trivy SARIF upload

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,7 @@ env:
 permissions:
   contents: read
   packages: write
+  security-events: write
 
 jobs:
   docker-build-test:


### PR DESCRIPTION
## Summary
- `security-events: write`権限を追加してTrivy脆弱性スキャン結果のSARIFアップロードを修正
- 「Resource not accessible by integration」エラーを解決

## 問題の詳細
GitHub ActionsのDocker security scanジョブで、TrivyがSARIFファイルを生成してCodeQLアクションがGitHub Security tabにアップロードしようとした際に権限エラーが発生していました。

エラーメッセージ：
```
Resource not accessible by integration - https://docs.github.com/rest
```

## 解決策
`permissions`セクションに`security-events: write`権限を追加しました。この権限により、セキュリティスキャン結果をGitHub Security タブにアップロードできるようになります。

## Test plan
- [x] ローカルでの単体テスト実行済み（pre-commitフックで自動実行）
- [x] YAML設定の検証済み
- [ ] GitHub Actionsでの動作確認（PRマージ後のmainブランチでの実行で確認予定）

🤖 Generated with [Claude Code](https://claude.ai/code)