### PR TITLE
fix: centralize logging in HTTP client layer for consistent PII masking

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,23 +1,11 @@
 #!/usr/bin/env python3
 """Main entry point for Authlete MCP Server."""
 
-import logging
-
+from src.authlete_mcp.logging import get_logger
 from src.authlete_mcp.server import run
 
-# Setup logging configuration for debugging
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    filename="/tmp/authlete_mcp.log",  # Log to file instead of stderr
-    filemode="w",  # Overwrite log file each time
-)
-
-# Enable debug logging for our modules
-logging.getLogger("authlete_mcp").setLevel(logging.DEBUG)
-logging.getLogger("src.authlete_mcp").setLevel(logging.DEBUG)
-
 if __name__ == "__main__":
-    logger = logging.getLogger(__name__)
-    logger.info("Starting Authlete MCP Server with debug logging...")
+    # Use our PII masking logger instead of standard logging
+    logger = get_logger(__name__)
+    logger.info("Starting Authlete MCP Server...")
     run()

--- a/src/authlete_mcp/api/client.py
+++ b/src/authlete_mcp/api/client.py
@@ -1,15 +1,15 @@
 """HTTP client for Authlete API."""
 
 import json
-import logging
 from typing import Any
 
 import httpx
 
 from ..config import AuthleteConfig
+from ..logging import get_logger, log_request_response
 
-# Set up logger
-logger = logging.getLogger(__name__)
+# Set up logger with PII masking
+logger = get_logger(__name__)
 
 
 async def make_authlete_request(
@@ -18,50 +18,64 @@ async def make_authlete_request(
     """Make a request to the Authlete API."""
 
     url = f"{config.base_url}/api/{endpoint}"
-    headers = {"Authorization": f"Bearer {config.api_key}", "Content-Type": "application/json"}
 
-    # Debug logging
-    logger.info(f"HTTP {method} {url}")
-    logger.info(f"Headers: {headers}")
-    if data:
-        logger.info(f"Request body: {json.dumps(data, indent=2)}")
-
-    async with httpx.AsyncClient() as client:
-        if method.upper() == "GET":
-            response = await client.get(url, headers=headers)
-        elif method.upper() == "POST":
-            response = await client.post(url, headers=headers, json=data)
-        elif method.upper() == "PUT":
-            response = await client.put(url, headers=headers, json=data)
-        elif method.upper() == "DELETE":
-            response = await client.delete(url, headers=headers)
-        else:
-            raise ValueError(f"Unsupported HTTP method: {method}")
-
-    # Debug response logging
-    logger.info(f"Response status: {response.status_code}")
-    logger.info(f"Response headers: {dict(response.headers)}")
     try:
-        response_body = response.json()
-        logger.info(f"Response body: {json.dumps(response_body, indent=2)}")
-    except json.JSONDecodeError:
-        logger.info(f"Response text: {response.text}")
+        # Use structured logging with PII masking
+        log_request_response(logger, method, url, request_data=data)
 
-    if response.status_code >= 400:
-        error_detail = response.text
+        headers = {"Authorization": f"Bearer {config.api_key}", "Content-Type": "application/json"}
+
+        async with httpx.AsyncClient() as client:
+            if method.upper() == "GET":
+                response = await client.get(url, headers=headers)
+            elif method.upper() == "POST":
+                response = await client.post(url, headers=headers, json=data)
+            elif method.upper() == "PUT":
+                response = await client.put(url, headers=headers, json=data)
+            elif method.upper() == "DELETE":
+                response = await client.delete(url, headers=headers)
+            else:
+                raise ValueError(f"Unsupported HTTP method: {method}")
+
+        if response.status_code >= 400:
+            error_detail = response.text
+            try:
+                error_json = response.json()
+                if "resultMessage" in error_json:
+                    error_detail = f"Authlete API Error: {error_json['resultMessage']}"
+            except json.JSONDecodeError:
+                pass
+
+            # Log error response
+            log_request_response(
+                logger,
+                method,
+                url,
+                status_code=response.status_code,
+                error=httpx.HTTPStatusError(error_detail, request=response.request, response=response),
+            )
+            raise httpx.HTTPStatusError(error_detail, request=response.request, response=response)
+
+        # Handle 204 No Content (successful deletion)
+        if response.status_code == 204:
+            result = {"success": True, "message": "Operation completed successfully"}
+            log_request_response(logger, method, url, response_data=result, status_code=response.status_code)
+            return result
+
         try:
-            error_json = response.json()
-            if "resultMessage" in error_json:
-                error_detail = f"Authlete API Error: {error_json['resultMessage']}"
+            result = response.json()
+            log_request_response(logger, method, url, response_data=result, status_code=response.status_code)
+            return result
         except json.JSONDecodeError:
-            pass
-        raise httpx.HTTPStatusError(error_detail, request=response.request, response=response)
+            result = {"text": response.text}
+            log_request_response(logger, method, url, response_data=result, status_code=response.status_code)
+            return result
 
-    # Handle 204 No Content (successful deletion)
-    if response.status_code == 204:
-        return {"success": True, "message": "Operation completed successfully"}
-
-    return response.json()
+    except Exception as e:
+        # Log any unexpected errors
+        if not isinstance(e, httpx.HTTPStatusError):
+            log_request_response(logger, method, url, request_data=data, error=e)
+        raise
 
 
 async def make_authlete_idp_request(
@@ -70,54 +84,75 @@ async def make_authlete_idp_request(
     """Make a request to the Authlete IdP API."""
 
     url = f"{config.idp_url}/api/{endpoint}"
-    headers = {"Authorization": f"Bearer {config.api_key}", "Content-Type": "application/json"}
 
-    # Debug logging
-    logger.info(f"HTTP {method} {url} (IdP API)")
-    logger.info(f"Headers: {headers}")
-    if data:
-        logger.info(f"Request body: {json.dumps(data, indent=2)}")
-
-    async with httpx.AsyncClient() as client:
-        if method.upper() == "GET":
-            response = await client.get(url, headers=headers)
-        elif method.upper() == "POST":
-            response = await client.post(url, headers=headers, json=data)
-        elif method.upper() == "PUT":
-            response = await client.put(url, headers=headers, json=data)
-        elif method.upper() == "DELETE":
-            response = await client.delete(url, headers=headers)
-        else:
-            raise ValueError(f"Unsupported HTTP method: {method}")
-
-    # Debug response logging
-    logger.info(f"Response status: {response.status_code} (IdP API)")
-    logger.info(f"Response headers: {dict(response.headers)}")
     try:
-        response_body = response.json()
-        logger.info(f"Response body: {json.dumps(response_body, indent=2)}")
-    except json.JSONDecodeError:
-        logger.info(f"Response text: {response.text}")
+        # Use structured logging with PII masking
+        log_request_response(logger, method, f"{url} (IdP API)", request_data=data)
 
-    if response.status_code >= 400:
-        error_detail = response.text
+        headers = {"Authorization": f"Bearer {config.api_key}", "Content-Type": "application/json"}
+
+        async with httpx.AsyncClient() as client:
+            if method.upper() == "GET":
+                response = await client.get(url, headers=headers)
+            elif method.upper() == "POST":
+                response = await client.post(url, headers=headers, json=data)
+            elif method.upper() == "PUT":
+                response = await client.put(url, headers=headers, json=data)
+            elif method.upper() == "DELETE":
+                response = await client.delete(url, headers=headers)
+            else:
+                raise ValueError(f"Unsupported HTTP method: {method}")
+
+        if response.status_code >= 400:
+            error_detail = response.text
+            try:
+                error_json = response.json()
+                if "resultMessage" in error_json:
+                    error_detail = f"Authlete IdP API Error: {error_json['resultMessage']}"
+            except json.JSONDecodeError:
+                pass
+
+            # Log error response
+            log_request_response(
+                logger,
+                method,
+                f"{url} (IdP API)",
+                status_code=response.status_code,
+                error=httpx.HTTPStatusError(error_detail, request=response.request, response=response),
+            )
+            raise httpx.HTTPStatusError(error_detail, request=response.request, response=response)
+
+        # Handle 204 No Content (successful deletion)
+        if response.status_code == 204:
+            result = {"success": True, "message": "Service deleted successfully"}
+            log_request_response(
+                logger, method, f"{url} (IdP API)", response_data=result, status_code=response.status_code
+            )
+            return result
+
+        # Handle empty response body
         try:
-            error_json = response.json()
-            if "resultMessage" in error_json:
-                error_detail = f"Authlete IdP API Error: {error_json['resultMessage']}"
+            result = response.json()
+            log_request_response(
+                logger, method, f"{url} (IdP API)", response_data=result, status_code=response.status_code
+            )
+            return result
         except json.JSONDecodeError:
-            pass
-        raise httpx.HTTPStatusError(error_detail, request=response.request, response=response)
+            # If response body is empty but status is success, return success message
+            if 200 <= response.status_code < 300:
+                result = {"success": True, "message": f"Operation completed with status {response.status_code}"}
+                log_request_response(
+                    logger, method, f"{url} (IdP API)", response_data=result, status_code=response.status_code
+                )
+                return result
+            result = {"error": "Empty response body", "status_code": response.status_code}
+            log_request_response(
+                logger, method, f"{url} (IdP API)", response_data=result, status_code=response.status_code
+            )
+            return result
 
-    # Handle 204 No Content (successful deletion)
-    if response.status_code == 204:
-        return {"success": True, "message": "Service deleted successfully"}
-
-    # Handle empty response body
-    try:
-        return response.json()
-    except json.JSONDecodeError:
-        # If response body is empty but status is success, return success message
-        if 200 <= response.status_code < 300:
-            return {"success": True, "message": f"Operation completed with status {response.status_code}"}
-        return {"error": "Empty response body", "status_code": response.status_code}
+    except Exception as e:
+        # Log any unexpected errors
+        if not isinstance(e, httpx.HTTPStatusError):
+            log_request_response(logger, method, f"{url} (IdP API)", request_data=data, error=e)
+        raise

--- a/src/authlete_mcp/tools/service_tools.py
+++ b/src/authlete_mcp/tools/service_tools.py
@@ -6,7 +6,6 @@ from mcp.server.fastmcp import Context
 
 from ..api.client import make_authlete_idp_request, make_authlete_request
 from ..config import DEFAULT_ORGANIZATION_ID, ORGANIZATION_ACCESS_TOKEN, AuthleteConfig
-from ..logging import get_logger, log_request_response
 
 
 async def create_service(name: str, description: str = "", ctx: Context = None) -> str:
@@ -16,8 +15,6 @@ async def create_service(name: str, description: str = "", ctx: Context = None) 
         name: Service name
         description: Service description
     """
-    logger = get_logger(__name__)
-
     if not ORGANIZATION_ACCESS_TOKEN:
         return "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
 
@@ -125,12 +122,9 @@ async def create_service(name: str, description: str = "", ctx: Context = None) 
     }
 
     try:
-        log_request_response(logger, "POST", "IdP API /service", request_data=data)
         result = await make_authlete_idp_request("POST", "service", config, data)
-        log_request_response(logger, "POST", "IdP API /service", response_data=result)
         return json.dumps(result, indent=2)
     except Exception as e:
-        log_request_response(logger, "POST", "IdP API /service", request_data=data, error=e)
         return f"Error creating service: {str(e)}"
 
 
@@ -143,8 +137,6 @@ async def create_service_detailed(
     Args:
         service_config: JSON string containing service configuration following Authlete API service schema
     """
-    logger = get_logger(__name__)
-
     if not ORGANIZATION_ACCESS_TOKEN:
         return "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
 
@@ -167,17 +159,12 @@ async def create_service_detailed(
             "service": service_dict,
         }
 
-        log_request_response(logger, "POST", "IdP API /service", request_data=data)
-
         # Send request to Authlete IdP API
         result = await make_authlete_idp_request("POST", "service", config, data)
-
-        log_request_response(logger, "POST", "IdP API /service", response_data=result)
 
         return json.dumps(result, indent=2)
 
     except Exception as e:
-        log_request_response(logger, "POST", "IdP API /service", request_data=data, error=e)
         return f"Error creating service: {str(e)}"
 
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- HTTPクライアントレベルでのPIIマスキング統合ロギングを実装
- 個別ツール関数からの分散ロギングコードを削除し、集約化
- main.pyのロギング設定競合問題を修正してLOG_LEVEL環境変数を有効化
- 全てのAuthlete API呼び出しで一貫した機密データマスキングを実現

## Test plan
- [x] Unit tests pass (pytest -m unit)
- [x] Logging functionality tests pass (pytest tests/test_logging.py)
- [x] Service deletion functionality verified
- [x] LOG_LEVEL environment variable works correctly
- [x] Code quality checks pass (ruff check/format)

## Technical Changes
- **`src/authlete_mcp/api/client.py`**: `make_authlete_request`と`make_authlete_idp_request`に統一ロギング実装
- **`src/authlete_mcp/tools/service_tools.py`**: 冗長な個別ロギングコードを削除
- **`main.py`**: `logging.basicConfig`による設定上書きを削除、PII マスキングロガーに統一
- **全体**: HTTPクライアントレベルでの集約ロギングアーキテクチャに移行

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)