### PR TITLE
refactor: rename AUTHLETE_BASE_URL to AUTHLETE_API_URL for clarity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
         env:
           ORGANIZATION_ACCESS_TOKEN: ${{ secrets.ORGANIZATION_ACCESS_TOKEN }}
           ORGANIZATION_ID: ${{ secrets.ORGANIZATION_ID }}
-          AUTHLETE_BASE_URL: "https://jp.authlete.com"
+          AUTHLETE_API_URL: "https://jp.authlete.com"
           AUTHLETE_IDP_URL: "https://login.authlete.com"
           AUTHLETE_API_SERVER_ID: "53285"
         run: |
@@ -191,7 +191,7 @@ jobs:
         env:
           ORGANIZATION_ACCESS_TOKEN: ${{ secrets.ORGANIZATION_ACCESS_TOKEN }}
           ORGANIZATION_ID: ${{ secrets.ORGANIZATION_ID }}
-          AUTHLETE_BASE_URL: "https://jp.authlete.com"
+          AUTHLETE_API_URL: "https://jp.authlete.com"
           AUTHLETE_IDP_URL: "https://login.authlete.com"
           AUTHLETE_API_SERVER_ID: "53285"
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ The server acts as a bridge between MCP clients (like Claude Desktop) and Authle
 - **Async/await pattern**: All API operations are asynchronous using `httpx` for HTTP requests
 - **DuckDB search engine**: `AuthleteApiSearcher` class in `src/authlete_mcp/search.py` provides fast, full-text search capabilities
 - **Two API endpoints**: 
-  - Authlete API (`AUTHLETE_BASE_URL`) for service/client management
+  - Authlete API (`AUTHLETE_API_URL`) for service/client management
   - Authlete IdP API (`AUTHLETE_IDP_URL`) for service creation/deletion operations
 - **Search database**: `resources/authlete_apis.duckdb` contains indexed API documentation for fast search
 
@@ -85,7 +85,7 @@ uv run yamllint .github/                # Lint YAML files with yamllint
 Required environment variables:
 - `ORGANIZATION_ACCESS_TOKEN`: Organization access token (required for all operations)
 - `ORGANIZATION_ID`: Default organization ID (optional, can be overridden per function)
-- `AUTHLETE_BASE_URL`: API base URL (defaults to "https://jp.authlete.com")
+- `AUTHLETE_API_URL`: API URL (defaults to "https://jp.authlete.com")
 - `AUTHLETE_IDP_URL`: IdP URL (defaults to "https://login.authlete.com") 
 - `AUTHLETE_API_SERVER_ID`: API Server ID (defaults to "53285")
 - `LOG_LEVEL`: Logging level (defaults to "INFO") - Set to "DEBUG" for detailed HTTP request/response logging with PII masking
@@ -179,7 +179,7 @@ When implementing or modifying MCP tools, follow these established patterns:
 2. **Success Responses**: Return formatted JSON using `json.dumps(result, indent=2)`
 3. **Deletion Success Messages**: Return clear success messages like `"Service deleted successfully (ID: {id})"`
 4. **API Endpoints**: 
-   - Use Authlete API (`AUTHLETE_BASE_URL`) for most operations
+   - Use Authlete API (`AUTHLETE_API_URL`) for most operations
    - Use Authlete IdP API (`AUTHLETE_IDP_URL`) for service creation/deletion operations
 
 ### Tool Categories and Patterns

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A unified Model Context Protocol (MCP) server that provides comprehensive tools 
 1. **Authlete Service Management**: Managing Authlete services and clients through a standardized interface
 2. **Advanced API Search**: Natural language search capabilities for Authlete OpenAPI specifications with fuzzy matching and semantic search
 
+**⚠️ Compatibility Note**: This server supports **Authlete 3.0 only**. It is not compatible with Authlete 2.3.
+
 ## Architecture
 
 The server follows a modular architecture with clear separation of concerns:
@@ -29,8 +31,9 @@ src/authlete_mcp/
 ### Reference Resources
 
 When implementing new Authlete API tools, please refer to these resource files:
-- `resources/postman_collection.json`: Complete Postman collection with all available Authlete API endpoints, request formats, and expected responses
+- `resources/postman_collection.json`: Postman collection for Authlete service and client management APIs including service operations, client operations, and tool-related endpoints
 - `resources/openapi-spec.json`: OpenAPI specification for Authlete API with detailed schema definitions and parameter descriptions
+- `resources/idp-openapi-spec.json`: Authlete IdP API specification for service creation and deletion operations (service create and service remove endpoints only)
 
 These resources provide authoritative examples of:
 - Correct API endpoint URLs and HTTP methods
@@ -157,7 +160,7 @@ docker run -it --rm \
 cat > .env << EOF
 ORGANIZATION_ACCESS_TOKEN=your-organization-token
 ORGANIZATION_ID=your-organization-id
-AUTHLETE_BASE_URL=https://jp.authlete.com
+AUTHLETE_API_URL=https://jp.authlete.com
 AUTHLETE_API_SERVER_ID=53285
 EOF
 
@@ -185,7 +188,7 @@ Add the unified server to your Claude Desktop configuration:
       "env": {
         "ORGANIZATION_ACCESS_TOKEN": "your-organization-access-token",
         "ORGANIZATION_ID": "your-organization-id", 
-        "AUTHLETE_BASE_URL": "https://jp.authlete.com",
+        "AUTHLETE_API_URL": "https://jp.authlete.com",
         "AUTHLETE_API_SERVER_ID": "53285",
         "LOG_LEVEL": "INFO"
       }
@@ -207,7 +210,7 @@ You can also run the server using Docker:
         "run", "--rm", "-i",
         "-e", "ORGANIZATION_ACCESS_TOKEN=your-organization-access-token",
         "-e", "ORGANIZATION_ID=your-organization-id",
-        "-e", "AUTHLETE_BASE_URL=https://jp.authlete.com",
+        "-e", "AUTHLETE_API_URL=https://jp.authlete.com",
         "-e", "AUTHLETE_API_SERVER_ID=53285",
         "-e", "LOG_LEVEL=INFO",
         "ghcr.io/watahani/authlete-mcp:latest"
@@ -226,8 +229,8 @@ uv run python main.py
 # Using custom organization access token
 ORGANIZATION_ACCESS_TOKEN=your-token uv run python main.py
 
-# Run with specific authlete server
-AUTHLETE_BASE_URL=https://eu.authlete.com uv run python main.py
+# Run with specific authlete server (EU region)
+AUTHLETE_API_URL=https://eu.authlete.com AUTHLETE_API_SERVER_ID=63294 uv run python main.py
 ```
 
 ## Configuration
@@ -239,10 +242,14 @@ The unified server supports the following environment variables:
 - `ORGANIZATION_ID`: Your organization ID (required for service creation and deletion operations)
 
 ### Optional Configuration
-- `AUTHLETE_BASE_URL`: Authlete API base URL (default: `https://jp.authlete.com`)
-- `AUTHLETE_IDP_URL`: Authlete IdP URL (default: `https://login.authlete.com`)
+- `AUTHLETE_API_URL`: Authlete API URL (default: `https://jp.authlete.com`)
 - `AUTHLETE_API_SERVER_ID`: API Server ID (default: `53285` for JP)
+- `AUTHLETE_IDP_URL`: Authlete IdP URL (default: `https://login.authlete.com`)
 - `LOG_LEVEL`: Logging level (default: `INFO`) - Set to `DEBUG` for detailed HTTP request/response logging with PII masking
+
+**⚠️ Important**: `AUTHLETE_API_URL` and `AUTHLETE_API_SERVER_ID` must be configured as a pair:
+- **JP region**: `AUTHLETE_API_URL=https://jp.authlete.com` + `AUTHLETE_API_SERVER_ID=53285`
+- **EU region**: `AUTHLETE_API_URL=https://eu.authlete.com` + `AUTHLETE_API_SERVER_ID=63294`
 
 ### API Search Requirements
 - `resources/authlete_apis.duckdb`: Search database file (created by `scripts/create_search_database.py`)
@@ -445,7 +452,7 @@ Retrieve sample code for a specific API endpoint in the requested language.
       "env": {
         "ORGANIZATION_ACCESS_TOKEN": "06uqWx-1R9pH8z07Ex3OxvBOdrwJeps-hPxxUm35uTc",
         "ORGANIZATION_ID": "143361107080408",
-        "AUTHLETE_BASE_URL": "https://jp.authlete.com",
+        "AUTHLETE_API_URL": "https://jp.authlete.com",
         "AUTHLETE_API_SERVER_ID": "53285"
       }
     }
@@ -472,9 +479,9 @@ For EU region (eu.authlete.com):
       "env": {
         "ORGANIZATION_ACCESS_TOKEN": "your-eu-org-token",
         "ORGANIZATION_ID": "your-eu-org-id",
-        "AUTHLETE_BASE_URL": "https://eu.authlete.com",
+        "AUTHLETE_API_URL": "https://eu.authlete.com",
         "AUTHLETE_IDP_URL": "https://login.authlete.com",
-        "AUTHLETE_API_SERVER_ID": "your-eu-api-server-id"
+        "AUTHLETE_API_SERVER_ID": "63294"
       }
     }
   }
@@ -488,7 +495,7 @@ For testing and development:
 # Set environment variables
 export ORGANIZATION_ACCESS_TOKEN="your-test-token"
 export ORGANIZATION_ID="your-test-org-id"
-export AUTHLETE_BASE_URL="https://jp.authlete.com"
+export AUTHLETE_API_URL="https://jp.authlete.com"
 export AUTHLETE_API_SERVER_ID="53285"
 
 # Run the server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - ORGANIZATION_ACCESS_TOKEN=${ORGANIZATION_ACCESS_TOKEN}
       - ORGANIZATION_ID=${ORGANIZATION_ID:-}
-      - AUTHLETE_BASE_URL=${AUTHLETE_BASE_URL:-https://jp.authlete.com}
+      - AUTHLETE_API_URL=${AUTHLETE_API_URL:-https://jp.authlete.com}
       - AUTHLETE_IDP_URL=${AUTHLETE_IDP_URL:-https://login.authlete.com}
       - AUTHLETE_API_SERVER_ID=${AUTHLETE_API_SERVER_ID:-53285}
       - PYTHONUNBUFFERED=1
@@ -36,7 +36,7 @@ services:
     environment:
       - ORGANIZATION_ACCESS_TOKEN=${ORGANIZATION_ACCESS_TOKEN}
       - ORGANIZATION_ID=${ORGANIZATION_ID:-}
-      - AUTHLETE_BASE_URL=${AUTHLETE_BASE_URL:-https://jp.authlete.com}
+      - AUTHLETE_API_URL=${AUTHLETE_API_URL:-https://jp.authlete.com}
       - AUTHLETE_IDP_URL=${AUTHLETE_IDP_URL:-https://login.authlete.com}
       - AUTHLETE_API_SERVER_ID=${AUTHLETE_API_SERVER_ID:-53285}
       - PYTHONUNBUFFERED=1

--- a/docs/API.md
+++ b/docs/API.md
@@ -143,7 +143,7 @@ The following environment variables are required:
 
 - `ORGANIZATION_ACCESS_TOKEN`: Authlete organization access token
 - `ORGANIZATION_ID`: Authlete organization ID
-- `AUTHLETE_BASE_URL` (optional): Authlete base URL (defaults to https://jp.authlete.com)
+- `AUTHLETE_API_URL` (optional): Authlete API URL (defaults to https://jp.authlete.com)
 - `AUTHLETE_IDP_URL` (optional): Authlete IdP URL (defaults to https://login.authlete.com)
 - `AUTHLETE_API_SERVER_ID` (optional): API Server ID (defaults to 53285)
 

--- a/examples/create_service_example.py
+++ b/examples/create_service_example.py
@@ -18,7 +18,7 @@ async def create_service_example():
         env={
             "ORGANIZATION_ACCESS_TOKEN": os.getenv("ORGANIZATION_ACCESS_TOKEN", ""),
             "ORGANIZATION_ID": os.getenv("ORGANIZATION_ID", ""),
-            "AUTHLETE_BASE_URL": os.getenv("AUTHLETE_BASE_URL", "https://jp.authlete.com"),
+            "AUTHLETE_API_URL": os.getenv("AUTHLETE_API_URL", "https://jp.authlete.com"),
             "AUTHLETE_API_SERVER_ID": os.getenv("AUTHLETE_API_SERVER_ID", "53285")
         }
     )

--- a/src/authlete_mcp/config.py
+++ b/src/authlete_mcp/config.py
@@ -5,7 +5,7 @@ import os
 from pydantic import BaseModel, Field
 
 # Configuration constants
-AUTHLETE_BASE_URL = os.getenv("AUTHLETE_BASE_URL", "https://jp.authlete.com")
+AUTHLETE_API_URL = os.getenv("AUTHLETE_API_URL", "https://jp.authlete.com")
 AUTHLETE_IDP_URL = os.getenv("AUTHLETE_IDP_URL", "https://login.authlete.com")
 DEFAULT_API_SERVER_ID = os.getenv("AUTHLETE_API_SERVER_ID", "53285")
 ORGANIZATION_ACCESS_TOKEN = os.getenv("ORGANIZATION_ACCESS_TOKEN", "")
@@ -16,6 +16,6 @@ class AuthleteConfig(BaseModel):
     """Configuration for Authlete API."""
 
     api_key: str = Field(..., description="Organization access token")
-    base_url: str = Field(default=AUTHLETE_BASE_URL, description="Authlete base URL")
+    base_url: str = Field(default=AUTHLETE_API_URL, description="Authlete API URL")
     idp_url: str = Field(default=AUTHLETE_IDP_URL, description="Authlete IdP URL")
     api_server_id: str = Field(default=DEFAULT_API_SERVER_ID, description="API Server ID")


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- 環境変数名を `AUTHLETE_BASE_URL` から `AUTHLETE_API_URL` に変更してより明確な命名に改善
- 全設定ファイル、ドキュメント、サンプルコードで一貫した命名規則を適用
- JP/EU地域のAPI URLとServer IDのペア設定要件を明記

## Changes
- **config.py**: 環境変数とフィールド名を更新
- **README.md**: 設定例、ドキュメント、重要な注意事項を更新
- **docker-compose.yml**: Docker環境設定を更新
- **CLAUDE.md**: プロジェクト内ドキュメントを更新
- **.github/workflows/test.yml**: CI/CD環境変数を更新
- **docs/API.md**: APIドキュメントを更新
- **examples/create_service_example.py**: サンプルコードを更新

## Benefits
- ✅ より明確な変数名: API エンドポイントであることが一目で分かる
- ✅ 混乱の削減: 用途が明確になり設定ミスを防止
- ✅ 地域設定の明確化: JP/EU地域のペア設定要件を文書化

## Test plan
- [x] Unit tests pass (pytest -m unit)
- [x] Code quality checks pass (ruff check/format)
- [x] All configuration files updated consistently
- [x] Documentation updated with correct environment variable names

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)