### PR TITLE
feat: add cross-platform Docker build support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,33 +33,55 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,amd64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
 
-      - name: Test Docker build
+      - name: Test Docker build (AMD64)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64
           push: false
-          tags: authlete-mcp:test
+          tags: authlete-mcp:test-amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
             BUILDKIT_INLINE_CACHE=1
 
-      - name: Test container startup
-        run: |
-          echo "Testing container startup..."
+      - name: Test Docker build (ARM64)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/arm64
+          push: false
+          tags: authlete-mcp:test-arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
 
-          # Build the image locally
-          docker build -t authlete-mcp:test .
+      - name: Test container startup (AMD64 only)
+        run: |
+          echo "Testing container startup on AMD64 platform..."
+
+          # Build the image locally for AMD64 only (for testing)
+          docker build -t authlete-mcp:test --platform linux/amd64 .
 
           # Test Python environment and module imports
           echo "Testing Python environment..."
-          docker run --rm --entrypoint="" authlete-mcp:test /usr/bin/python3.11 -c "
+          docker run --rm --platform linux/amd64 --entrypoint="" authlete-mcp:test /usr/bin/python3.11 -c "
           import sys
           print('✅ Python version:', sys.version)
+          print('✅ Platform:', sys.platform)
 
           # Test essential package imports
           packages = ['duckdb', 'pydantic', 'httpx', 'mcp']
@@ -84,7 +106,7 @@ jobs:
 
           # Test actual container startup (with timeout)
           echo "Testing container startup with MCP server..."
-          timeout 10s docker run --rm \
+          timeout 10s docker run --rm --platform linux/amd64 \
             -e ORGANIZATION_ACCESS_TOKEN="dummy_token" \
             -e ORGANIZATION_ID="test_org" \
             authlete-mcp:test 2>&1 | tee startup_log.txt &
@@ -103,8 +125,12 @@ jobs:
       - name: Check image size
         run: |
           echo "Checking Docker image size..."
-          IMAGE_SIZE=$(docker images authlete-mcp:test --format "table {{.Size}}" | tail -n 1)
-          echo "📏 Docker image size: $IMAGE_SIZE"
+          if docker images authlete-mcp:test --format "table {{.Size}}" | tail -n 1 > /dev/null 2>&1; then
+            IMAGE_SIZE=$(docker images authlete-mcp:test --format "table {{.Size}}" | tail -n 1)
+            echo "📏 Docker image size (AMD64): $IMAGE_SIZE"
+          else
+            echo "📏 Cross-platform images built successfully (size check skipped for multi-arch)"
+          fi
 
       - name: Test Docker Compose
         run: |
@@ -130,8 +156,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,amd64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
 
       - name: Log in to Container Registry
         uses: docker/login-action@v3
@@ -158,6 +191,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -177,13 +211,20 @@ jobs:
             echo "- \`$tag\`" >> $GITHUB_STEP_SUMMARY
           done
           echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Platforms:** linux/amd64, linux/arm64" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Usage" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "# Pull the image" >> $GITHUB_STEP_SUMMARY
+          echo "# Pull the image (supports both AMD64 and ARM64)" >> $GITHUB_STEP_SUMMARY
           echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "# Run with environment variables" >> $GITHUB_STEP_SUMMARY
           echo "docker run -it --rm \\" >> $GITHUB_STEP_SUMMARY
+          echo "  -e ORGANIZATION_ACCESS_TOKEN=\\\$YOUR_TOKEN \\" >> $GITHUB_STEP_SUMMARY
+          echo "  ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "# For specific platform (optional)" >> $GITHUB_STEP_SUMMARY
+          echo "docker run --platform linux/arm64 -it --rm \\" >> $GITHUB_STEP_SUMMARY
           echo "  -e ORGANIZATION_ACCESS_TOKEN=\\\$YOUR_TOKEN \\" >> $GITHUB_STEP_SUMMARY
           echo "  ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
@@ -197,14 +238,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,amd64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
 
-      - name: Build image for scanning
+      - name: Build image for scanning (AMD64 only)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64
           load: true
           tags: authlete-mcp:scan
           cache-from: type=gha


### PR DESCRIPTION
## Summary
- DockerイメージをAMD64とARM64の両プラットフォームでビルドできるよう修正
- QEMUエミュレーションを追加してクロスプラットフォームビルドを有効化
- ビルドとテストワークフローをマルチプラットフォーム対応に更新
- セキュリティスキャンはAMD64プラットフォームでのみ実行（パフォーマンス最適化）

## Test plan
- [x] YAML構文チェック通過 (yamllint)
- [x] ローカルでのDockerビルドテスト実行
- [x] Unit tests 通過 (pytest -m unit)
- [x] Pre-commitフック全て通過
- [x] GitHub ActionsでのDocker workflowテスト待機

## Technical Changes
### GitHub Actions (.github/workflows/docker.yml)
- `docker/setup-qemu-action@v3` を追加してARM64エミュレーション有効化
- `platforms: linux/amd64,linux/arm64` を全ビルドステップに追加
- テストは実行速度のためAMD64のみで実行
- デプロイメント情報にプラットフォーム対応状況を追加

### ビルド戦略
1. **docker-build-test**: 両プラットフォームでビルドテスト、AMD64で動作テスト
2. **docker-publish**: 両プラットフォームでイメージを公開  
3. **docker-security-scan**: AMD64でのみセキュリティスキャン実行

## Breaking Changes
なし（下位互換性を維持）

🤖 Generated with [Claude Code](https://claude.ai/code)