### PR TITLE
refactor: rename AuthleteConfig api_key parameter to access_token

### DIFF
--- a/scripts/cleanup_test_services.py
+++ b/scripts/cleanup_test_services.py
@@ -84,7 +84,7 @@ async def cleanup_test_services():
         print("⚠️ ORGANIZATION_ID not set, using empty string")
 
     # Create config
-    config = AuthleteConfig(api_key=org_token)
+    config = AuthleteConfig(access_token=org_token)
 
     # List all services
     services = await list_all_services(config)

--- a/scripts/create_test_services.py
+++ b/scripts/create_test_services.py
@@ -67,7 +67,7 @@ async def create_test_services():
         return False
 
     # Create config
-    config = AuthleteConfig(api_key=org_token)
+    config = AuthleteConfig(access_token=org_token)
 
     # Create services
     created_count = 0

--- a/src/authlete_mcp/api/client.py
+++ b/src/authlete_mcp/api/client.py
@@ -23,7 +23,7 @@ async def make_authlete_request(
         # Use structured logging with PII masking
         log_request_response(logger, method, url, request_data=data)
 
-        headers = {"Authorization": f"Bearer {config.api_key}", "Content-Type": "application/json"}
+        headers = {"Authorization": f"Bearer {config.access_token}", "Content-Type": "application/json"}
 
         async with httpx.AsyncClient() as client:
             if method.upper() == "GET":
@@ -89,7 +89,7 @@ async def make_authlete_idp_request(
         # Use structured logging with PII masking
         log_request_response(logger, method, f"{url} (IdP API)", request_data=data)
 
-        headers = {"Authorization": f"Bearer {config.api_key}", "Content-Type": "application/json"}
+        headers = {"Authorization": f"Bearer {config.access_token}", "Content-Type": "application/json"}
 
         async with httpx.AsyncClient() as client:
             if method.upper() == "GET":

--- a/src/authlete_mcp/config.py
+++ b/src/authlete_mcp/config.py
@@ -15,7 +15,7 @@ DEFAULT_ORGANIZATION_ID = os.getenv("ORGANIZATION_ID", "")
 class AuthleteConfig(BaseModel):
     """Configuration for Authlete API."""
 
-    api_key: str = Field(..., description="Organization access token")
+    access_token: str = Field(..., description="Organization access token")
     base_url: str = Field(default=AUTHLETE_API_URL, description="Authlete API URL")
     idp_url: str = Field(default=AUTHLETE_IDP_URL, description="Authlete IdP URL")
     api_server_id: str = Field(default=DEFAULT_API_SERVER_ID, description="API Server ID")

--- a/src/authlete_mcp/tools/client_tools.py
+++ b/src/authlete_mcp/tools/client_tools.py
@@ -25,7 +25,7 @@ async def create_client(client_data: str, service_api_key: str = "") -> str:
     if not ORGANIZATION_ACCESS_TOKEN:
         return "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
 
-    config = AuthleteConfig(api_key=ORGANIZATION_ACCESS_TOKEN)
+    config = AuthleteConfig(access_token=ORGANIZATION_ACCESS_TOKEN)
 
     try:
         data = json.loads(client_data)
@@ -55,7 +55,7 @@ async def get_client(client_id: str, service_api_key: str = "") -> str:
     if not ORGANIZATION_ACCESS_TOKEN:
         return "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
 
-    config = AuthleteConfig(api_key=ORGANIZATION_ACCESS_TOKEN)
+    config = AuthleteConfig(access_token=ORGANIZATION_ACCESS_TOKEN)
 
     try:
         result = await make_authlete_request("GET", f"{service_api_key}/client/get/{client_id}", config)
@@ -81,7 +81,7 @@ async def list_clients(service_api_key: str = "", limit: int = 100) -> str:
     if not ORGANIZATION_ACCESS_TOKEN:
         return "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
 
-    config = AuthleteConfig(api_key=ORGANIZATION_ACCESS_TOKEN)
+    config = AuthleteConfig(access_token=ORGANIZATION_ACCESS_TOKEN)
 
     all_clients = []
     start = 0
@@ -188,7 +188,7 @@ async def update_client(client_id: str, client_data: str, service_api_key: str =
     if not ORGANIZATION_ACCESS_TOKEN:
         return "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
 
-    config = AuthleteConfig(api_key=ORGANIZATION_ACCESS_TOKEN)
+    config = AuthleteConfig(access_token=ORGANIZATION_ACCESS_TOKEN)
 
     try:
         data = json.loads(client_data)
@@ -217,7 +217,7 @@ async def delete_client(client_id: str, service_api_key: str = "") -> str:
     if not ORGANIZATION_ACCESS_TOKEN:
         return "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
 
-    config = AuthleteConfig(api_key=ORGANIZATION_ACCESS_TOKEN)
+    config = AuthleteConfig(access_token=ORGANIZATION_ACCESS_TOKEN)
 
     try:
         result = await make_authlete_request("DELETE", f"{service_api_key}/client/delete/{client_id}", config)
@@ -243,7 +243,7 @@ async def rotate_client_secret(client_id: str, service_api_key: str = "") -> str
     if not ORGANIZATION_ACCESS_TOKEN:
         return "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
 
-    config = AuthleteConfig(api_key=ORGANIZATION_ACCESS_TOKEN)
+    config = AuthleteConfig(access_token=ORGANIZATION_ACCESS_TOKEN)
 
     try:
         result = await make_authlete_request("GET", f"{service_api_key}/client/secret/refresh/{client_id}", config)
@@ -272,7 +272,7 @@ async def update_client_secret(client_id: str, secret_data: str, service_api_key
     if not ORGANIZATION_ACCESS_TOKEN:
         return "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
 
-    config = AuthleteConfig(api_key=ORGANIZATION_ACCESS_TOKEN)
+    config = AuthleteConfig(access_token=ORGANIZATION_ACCESS_TOKEN)
 
     try:
         data = json.loads(secret_data)
@@ -306,7 +306,7 @@ async def update_client_lock(client_id: str, lock_flag: bool, service_api_key: s
     if not ORGANIZATION_ACCESS_TOKEN:
         return "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
 
-    config = AuthleteConfig(api_key=ORGANIZATION_ACCESS_TOKEN)
+    config = AuthleteConfig(access_token=ORGANIZATION_ACCESS_TOKEN)
 
     data = {"locked": lock_flag}
 
@@ -338,7 +338,7 @@ async def get_authorized_applications(
         if not subject:
             return "Error: subject parameter is required"
 
-        config = AuthleteConfig(api_key=service_api_key)
+        config = AuthleteConfig(access_token=service_api_key)
 
         # Make request to Authlete API
         result = await make_authlete_request("GET", f"auth/authorization/application/{subject}", config)
@@ -384,7 +384,7 @@ async def update_client_tokens(
         except json.JSONDecodeError as e:
             return f"Error parsing token data JSON: {str(e)}"
 
-        config = AuthleteConfig(api_key=service_api_key)
+        config = AuthleteConfig(access_token=service_api_key)
 
         # Make request to Authlete API
         result = await make_authlete_request(
@@ -425,7 +425,7 @@ async def delete_client_tokens(
         if not client_id:
             return "Error: client_id parameter is required"
 
-        config = AuthleteConfig(api_key=service_api_key)
+        config = AuthleteConfig(access_token=service_api_key)
 
         # Make request to Authlete API
         result = await make_authlete_request("DELETE", f"auth/authorization/application/{subject}/{client_id}", config)
@@ -464,7 +464,7 @@ async def get_granted_scopes(
         if not client_id:
             return "Error: client_id parameter is required"
 
-        config = AuthleteConfig(api_key=service_api_key)
+        config = AuthleteConfig(access_token=service_api_key)
 
         # Make request to Authlete API
         result = await make_authlete_request("GET", f"auth/authorization/grant/{subject}/{client_id}", config)
@@ -503,7 +503,7 @@ async def delete_granted_scopes(
         if not client_id:
             return "Error: client_id parameter is required"
 
-        config = AuthleteConfig(api_key=service_api_key)
+        config = AuthleteConfig(access_token=service_api_key)
 
         # Make request to Authlete API
         result = await make_authlete_request("DELETE", f"auth/authorization/grant/{subject}/{client_id}", config)
@@ -537,7 +537,7 @@ async def get_requestable_scopes(
         if not client_id:
             return "Error: client_id parameter is required"
 
-        config = AuthleteConfig(api_key=service_api_key)
+        config = AuthleteConfig(access_token=service_api_key)
 
         # Make request to Authlete API
         result = await make_authlete_request("GET", f"client/requestable_scopes/{client_id}", config)
@@ -581,7 +581,7 @@ async def update_requestable_scopes(
         except json.JSONDecodeError as e:
             return f"Error parsing scopes data JSON: {str(e)}"
 
-        config = AuthleteConfig(api_key=service_api_key)
+        config = AuthleteConfig(access_token=service_api_key)
 
         # Make request to Authlete API
         result = await make_authlete_request("PUT", f"client/requestable_scopes/{client_id}", config, scopes_params)
@@ -615,7 +615,7 @@ async def delete_requestable_scopes(
         if not client_id:
             return "Error: client_id parameter is required"
 
-        config = AuthleteConfig(api_key=service_api_key)
+        config = AuthleteConfig(access_token=service_api_key)
 
         # Make request to Authlete API
         result = await make_authlete_request("DELETE", f"client/requestable_scopes/{client_id}", config)

--- a/src/authlete_mcp/tools/jose_tools.py
+++ b/src/authlete_mcp/tools/jose_tools.py
@@ -97,7 +97,7 @@ async def verify_jose(
         if not ORGANIZATION_ACCESS_TOKEN:
             return "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
 
-        config = AuthleteConfig(api_key=service_api_key)
+        config = AuthleteConfig(access_token=service_api_key)
 
         # Make request to Authlete API
         result = await make_authlete_request("POST", "jose/verify", config, {"jose": jose_token})

--- a/src/authlete_mcp/tools/service_tools.py
+++ b/src/authlete_mcp/tools/service_tools.py
@@ -21,7 +21,7 @@ async def create_service(name: str, description: str = "", ctx: Context = None) 
     if not DEFAULT_ORGANIZATION_ID:
         return "Error: ORGANIZATION_ID environment variable must be set"
 
-    config = AuthleteConfig(api_key=ORGANIZATION_ACCESS_TOKEN)
+    config = AuthleteConfig(access_token=ORGANIZATION_ACCESS_TOKEN)
 
     # Create service configuration for IdP API (without number, serviceOwnerNumber, apiKey, cluster)
     service_data = {
@@ -143,7 +143,7 @@ async def create_service_detailed(
     if not DEFAULT_ORGANIZATION_ID:
         return "Error: ORGANIZATION_ID environment variable must be set"
 
-    config = AuthleteConfig(api_key=ORGANIZATION_ACCESS_TOKEN)
+    config = AuthleteConfig(access_token=ORGANIZATION_ACCESS_TOKEN)
 
     try:
         # Parse service configuration JSON
@@ -217,7 +217,7 @@ async def get_service(service_api_key: str = "", ctx: Context = None) -> str:
     if not ORGANIZATION_ACCESS_TOKEN:
         return "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
 
-    config = AuthleteConfig(api_key=ORGANIZATION_ACCESS_TOKEN)
+    config = AuthleteConfig(access_token=ORGANIZATION_ACCESS_TOKEN)
     key_to_use = service_api_key if service_api_key else ORGANIZATION_ACCESS_TOKEN
 
     try:
@@ -236,7 +236,7 @@ async def list_services(limit: int = 100, ctx: Context = None) -> str:
     if not ORGANIZATION_ACCESS_TOKEN:
         return "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
 
-    config = AuthleteConfig(api_key=ORGANIZATION_ACCESS_TOKEN)
+    config = AuthleteConfig(access_token=ORGANIZATION_ACCESS_TOKEN)
 
     all_services = []
     start = 0
@@ -338,7 +338,7 @@ async def update_service(service_data: str, service_api_key: str = "", ctx: Cont
     if not ORGANIZATION_ACCESS_TOKEN:
         return "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
 
-    config = AuthleteConfig(api_key=ORGANIZATION_ACCESS_TOKEN)
+    config = AuthleteConfig(access_token=ORGANIZATION_ACCESS_TOKEN)
     key_to_use = service_api_key if service_api_key else ORGANIZATION_ACCESS_TOKEN
 
     try:
@@ -363,7 +363,7 @@ async def delete_service(service_id: str, ctx: Context = None) -> str:
     if not DEFAULT_ORGANIZATION_ID:
         return "Error: ORGANIZATION_ID environment variable must be set"
 
-    config = AuthleteConfig(api_key=ORGANIZATION_ACCESS_TOKEN)
+    config = AuthleteConfig(access_token=ORGANIZATION_ACCESS_TOKEN)
 
     # Try with environment variable values first
     data = {

--- a/src/authlete_mcp/tools/token_tools.py
+++ b/src/authlete_mcp/tools/token_tools.py
@@ -31,7 +31,7 @@ async def list_issued_tokens(
         if not ORGANIZATION_ACCESS_TOKEN:
             return "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
 
-        config = AuthleteConfig(api_key=service_api_key)
+        config = AuthleteConfig(access_token=service_api_key)
 
         # Build query parameters
         params = {}
@@ -79,7 +79,7 @@ async def create_access_token(
         except json.JSONDecodeError as e:
             return f"Error parsing token data JSON: {str(e)}"
 
-        config = AuthleteConfig(api_key=service_api_key)
+        config = AuthleteConfig(access_token=service_api_key)
 
         # Make request to Authlete API
         result = await make_authlete_request("POST", "auth/token/create", config, token_params)
@@ -121,7 +121,7 @@ async def update_access_token(
         except json.JSONDecodeError as e:
             return f"Error parsing token data JSON: {str(e)}"
 
-        config = AuthleteConfig(api_key=service_api_key)
+        config = AuthleteConfig(access_token=service_api_key)
 
         # Make request to Authlete API
         result = await make_authlete_request("PUT", f"auth/token/update/{access_token}", config, token_params)
@@ -155,7 +155,7 @@ async def revoke_access_token(
         if not access_token:
             return "Error: access_token parameter is required"
 
-        config = AuthleteConfig(api_key=service_api_key)
+        config = AuthleteConfig(access_token=service_api_key)
 
         # Make request to Authlete API
         result = await make_authlete_request("POST", f"auth/token/revoke/{access_token}", config)
@@ -189,7 +189,7 @@ async def delete_access_token(
         if not access_token:
             return "Error: access_token parameter is required"
 
-        config = AuthleteConfig(api_key=service_api_key)
+        config = AuthleteConfig(access_token=service_api_key)
 
         # Make request to Authlete API
         result = await make_authlete_request("DELETE", f"auth/token/delete/{access_token}", config)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- `AuthleteConfig`クラスの`api_key`フィールドを`access_token`に変更してパラメータ名を明確化
- 全ツールとスクリプトでの`AuthleteConfig`インスタンス化箇所を更新
- HTTPクライアントでBearer認証に`config.access_token`を使用するよう修正
- 実際の使用目的に合わせてパラメータ命名の一貫性を改善

## Test plan
- [x] Unit tests pass (pytest -m unit)
- [x] Code quality checks pass (ruff check/format)
- [x] Pre-commit hooks pass successfully
- [x] Manual verification: all `AuthleteConfig(api_key=...)` → `AuthleteConfig(access_token=...)`

## Breaking Changes
なし（内部実装の変更のみ）

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)