### PR TITLE
fix: update IdP OpenAPI spec to use production URL and refresh specification

### DIFF
--- a/resources/idp-openapi-spec.json
+++ b/resources/idp-openapi-spec.json
@@ -6,7 +6,7 @@
   },
   "servers": [
     {
-      "url": "https://dev-idp.authlete.net",
+      "url": "https://login.authlete.com",
       "description": "Generated server url"
     }
   ],
@@ -2489,7 +2489,7 @@
         "tags": [
           "api-server-api"
         ],
-        "summary": "Get a list of all api servers available to you, or to the organization token.\nApi servers associated with organizations that you or the org token\nare not a part of are not returned.\nFor admin users, all api servers are returned.\n",
+        "summary": "Get a list of all api servers available to you.\nApi servers associated with organizations that you are not a part of are not returned.\nFor admin users, all api servers are returned.",
         "operationId": "getAllApiServers",
         "parameters": [
           {
@@ -3542,26 +3542,6 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/config.js": {
-      "get": {
-        "tags": [
-          "frontend-config-api"
-        ],
-        "operationId": "getFrontendConfig",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/javascript": {
                 "schema": {
                   "type": "string"
                 }

--- a/resources/idp-openapi-spec.yaml
+++ b/resources/idp-openapi-spec.yaml
@@ -3,7 +3,7 @@ info:
   title: OpenAPI definition
   version: v0
 servers:
-- url: https://dev-idp.authlete.net
+- url: https://login.authlete.com
   description: Generated server url
 paths:
   /token:
@@ -1614,16 +1614,12 @@ paths:
     get:
       tags:
       - api-server-api
-      summary: 'Get a list of all api servers available to you, or to the organization
-        token.
+      summary: 'Get a list of all api servers available to you.
 
-        Api servers associated with organizations that you or the org token
+        Api servers associated with organizations that you are not a part of are not
+        returned.
 
-        are not a part of are not returned.
-
-        For admin users, all api servers are returned.
-
-        '
+        For admin users, all api servers are returned.'
       operationId: getAllApiServers
       parameters:
       - name: Authorization
@@ -2350,18 +2346,6 @@ paths:
           description: OK
           content:
             application/json:
-              schema:
-                type: string
-  /config.js:
-    get:
-      tags:
-      - frontend-config-api
-      operationId: getFrontendConfig
-      responses:
-        '200':
-          description: OK
-          content:
-            application/javascript:
               schema:
                 type: string
   /api/user/{id}/auth:

--- a/scripts/update_idp_openapi_spec.py
+++ b/scripts/update_idp_openapi_spec.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import httpx
 import yaml
 
-AUTHLETE_IDP_SPEC_URL = "https://dev-idp.authlete.net/v3/api-docs.yaml"
+AUTHLETE_IDP_SPEC_URL = "https://login.authlete.com/v3/api-docs.yaml"
 RESOURCES_DIR = Path(__file__).parent.parent / "resources"
 IDP_OPENAPI_SPEC_FILE = RESOURCES_DIR / "idp-openapi-spec.yaml"
 IDP_OPENAPI_SPEC_JSON_FILE = RESOURCES_DIR / "idp-openapi-spec.json"


### PR DESCRIPTION
## Summary
- Update `scripts/update_idp_openapi_spec.py` to use production Authlete IdP API URL
- Execute the script to refresh IdP OpenAPI specification from production environment
- Fix hardcoded development URL to proper production URL

## Changes
- Changed AUTHLETE_IDP_SPEC_URL from `https://dev-idp.authlete.net/v3/api-docs.yaml` to `https://login.authlete.com/v3/api-docs.yaml`
- Updated `resources/idp-openapi-spec.yaml` and `resources/idp-openapi-spec.json` with latest production specification
- Path count updated from 79 to 78 endpoints (specification refinement from production)

## Test plan
- [x] Script execution completed successfully (153161 bytes downloaded)
- [x] Generated files are valid YAML/JSON format
- [x] No breaking changes to existing MCP tool functionality
- [x] Code quality checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)