### PR TITLE
Support dynamic API server precedence

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      max-parallel: 1
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ docker run -it --rm \
 cat > .env << EOF
 ORGANIZATION_ACCESS_TOKEN=your-organization-token
 ORGANIZATION_ID=your-organization-id
+# Optional but recommended when you want a deterministic default
 AUTHLETE_API_URL=https://jp.authlete.com
 AUTHLETE_API_SERVER_ID=53285
 EOF
@@ -190,14 +191,16 @@ Add the unified server to your Claude Desktop configuration:
       "env": {
         "ORGANIZATION_ACCESS_TOKEN": "your-organization-access-token",
         "ORGANIZATION_ID": "your-organization-id", 
-        "AUTHLETE_API_URL": "https://jp.authlete.com",
-        "AUTHLETE_API_SERVER_ID": "53285",
+        // "AUTHLETE_API_URL": "https://jp.authlete.com",
+        // "AUTHLETE_API_SERVER_ID": "53285",
         "LOG_LEVEL": "INFO"
       }
     }
   }
 }
 ```
+
+`AUTHLETE_API_URL` and `AUTHLETE_API_SERVER_ID` act as optional defaults—you can omit them and call `set_api_server` after connecting if you prefer to choose dynamically.
 
 #### Docker Installation
 
@@ -212,8 +215,8 @@ You can also run the server using Docker:
         "run", "--rm", "-i",
         "-e", "ORGANIZATION_ACCESS_TOKEN=your-organization-access-token",
         "-e", "ORGANIZATION_ID=your-organization-id",
-        "-e", "AUTHLETE_API_URL=https://jp.authlete.com",
-        "-e", "AUTHLETE_API_SERVER_ID=53285",
+        // "-e", "AUTHLETE_API_URL=https://jp.authlete.com",
+        // "-e", "AUTHLETE_API_SERVER_ID=53285",
         "-e", "LOG_LEVEL=INFO",
         "ghcr.io/watahani/authlete-mcp:latest"
       ]
@@ -221,6 +224,8 @@ You can also run the server using Docker:
   }
 }
 ```
+
+The Docker example shows the optional defaults as well; remove them if you want the MCP client to decide the API server through `set_api_server`.
 
 ### Direct Usage
 
@@ -231,8 +236,9 @@ uv run python main.py
 # Using custom organization access token
 ORGANIZATION_ACCESS_TOKEN=your-token uv run python main.py
 
-# Run with specific authlete server (EU region)
+# Run with specific Authlete server defaults (optional)
 AUTHLETE_API_URL=https://eu.authlete.com AUTHLETE_API_SERVER_ID=63294 uv run python main.py
+# You can also omit these and call `set_api_server` from the client to choose dynamically
 ```
 
 ## Configuration
@@ -244,14 +250,18 @@ The unified server supports the following environment variables:
 - `ORGANIZATION_ID`: Your organization ID (required for service creation and deletion operations)
 
 ### Optional Configuration
-- `AUTHLETE_API_URL`: Authlete API URL (default: `https://jp.authlete.com`)
-- `AUTHLETE_API_SERVER_ID`: API Server ID (default: `53285` for JP)
+- `AUTHLETE_API_URL`: Optional default Authlete API URL
+- `AUTHLETE_API_SERVER_ID`: Optional default API server ID. When provided together with `AUTHLETE_API_URL`, the pair becomes the starting configuration for all tools.
 - `AUTHLETE_IDP_URL`: Authlete IdP URL (default: `https://login.authlete.com`)
 - `LOG_LEVEL`: Logging level (default: `INFO`) - Set to `DEBUG` for detailed HTTP request/response logging with PII masking
 
-**⚠️ Important**: `AUTHLETE_API_URL` and `AUTHLETE_API_SERVER_ID` must be configured as a pair:
-- **JP region**: `AUTHLETE_API_URL=https://jp.authlete.com` + `AUTHLETE_API_SERVER_ID=53285`
-- **EU region**: `AUTHLETE_API_URL=https://eu.authlete.com` + `AUTHLETE_API_SERVER_ID=63294`
+**API server precedence**
+1. Tool parameters (e.g., `create_service_detailed(apiServerId=...)`) and the `set_api_server` tool
+2. Currently configured server from a previous `set_api_server` call or auto-detection within the same process
+3. Environment defaults supplied via `AUTHLETE_API_URL` and `AUTHLETE_API_SERVER_ID`
+4. Automatic discovery based on `AUTHLETE_API_URL` (if provided) followed by an instruction to run `list_api_servers`/`set_api_server` when no match is found
+
+When you supply environment defaults, specify both values so the server is selected deterministically (examples: `JP` region → `AUTHLETE_API_URL=https://jp.authlete.com`, `AUTHLETE_API_SERVER_ID=53285`; `EU` region → `AUTHLETE_API_URL=https://eu.authlete.com`, `AUTHLETE_API_SERVER_ID=63294`).
 
 ### API Search Requirements
 - `resources/authlete_apis.duckdb`: Search database file (created by `scripts/create_search_database.py`)

--- a/README.md
+++ b/README.md
@@ -250,7 +250,8 @@ The unified server supports the following environment variables:
 - `ORGANIZATION_ID`: Your organization ID (required for service creation and deletion operations)
 
 ### Optional Configuration
-- `AUTHLETE_API_URL`: Optional default Authlete API URL
+- `AUTHLETE_API_URL`: Optional default Authlete API URL (falls back to `https://jp.authlete.com` when unset)
+- `AUTHLETE_BASE_URL`: Legacy alias for `AUTHLETE_API_URL` (supported for backward compatibility but deprecated)
 - `AUTHLETE_API_SERVER_ID`: Optional default API server ID. When provided together with `AUTHLETE_API_URL`, the pair becomes the starting configuration for all tools.
 - `AUTHLETE_IDP_URL`: Authlete IdP URL (default: `https://login.authlete.com`)
 - `LOG_LEVEL`: Logging level (default: `INFO`) - Set to `DEBUG` for detailed HTTP request/response logging with PII masking

--- a/src/authlete_mcp/api/client.py
+++ b/src/authlete_mcp/api/client.py
@@ -78,18 +78,106 @@ async def make_authlete_request(
         raise
 
 
+async def make_authlete_request_with_dynamic_server(
+    method: str, endpoint: str, access_token: str, data: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Make a request to the Authlete API with dynamic server selection."""
+    from ..config import ensure_api_server_configured, get_api_server_url
+
+    # Ensure API server is configured
+    error_msg = await ensure_api_server_configured()
+    if error_msg:
+        raise RuntimeError(error_msg)
+
+    api_url = get_api_server_url()
+    if not api_url:
+        raise RuntimeError("API server URL not available")
+
+    url = f"{api_url}/api/{endpoint}"
+
+    try:
+        # Use structured logging with PII masking
+        log_request_response(logger, method, url, request_data=data)
+
+        headers = {"Authorization": f"Bearer {access_token}", "Content-Type": "application/json"}
+
+        async with httpx.AsyncClient() as client:
+            if method.upper() == "GET":
+                response = await client.get(url, headers=headers)
+            elif method.upper() == "POST":
+                response = await client.post(url, headers=headers, json=data)
+            elif method.upper() == "PUT":
+                response = await client.put(url, headers=headers, json=data)
+            elif method.upper() == "DELETE":
+                response = await client.delete(url, headers=headers)
+            else:
+                raise ValueError(f"Unsupported HTTP method: {method}")
+
+        if response.status_code >= 400:
+            error_detail = response.text
+            try:
+                error_json = response.json()
+                if "resultMessage" in error_json:
+                    error_detail = f"Authlete API Error: {error_json['resultMessage']}"
+            except json.JSONDecodeError:
+                pass
+
+            # Log error response
+            log_request_response(
+                logger,
+                method,
+                url,
+                status_code=response.status_code,
+                error=httpx.HTTPStatusError(error_detail, request=response.request, response=response),
+            )
+            raise httpx.HTTPStatusError(error_detail, request=response.request, response=response)
+
+        # Handle 204 No Content (successful deletion)
+        if response.status_code == 204:
+            result = {"success": True, "message": "Operation completed successfully"}
+            log_request_response(logger, method, url, response_data=result, status_code=response.status_code)
+            return result
+
+        try:
+            result = response.json()
+            log_request_response(logger, method, url, response_data=result, status_code=response.status_code)
+            return result
+        except json.JSONDecodeError:
+            result = {"text": response.text}
+            log_request_response(logger, method, url, response_data=result, status_code=response.status_code)
+            return result
+
+    except Exception as e:
+        # Log any unexpected errors
+        if not isinstance(e, httpx.HTTPStatusError):
+            log_request_response(logger, method, url, request_data=data, error=e)
+        raise
+
+
 async def make_authlete_idp_request(
-    method: str, endpoint: str, config: AuthleteConfig, data: dict[str, Any] | None = None
+    endpoint: str,
+    method: str = "GET",
+    access_token: str | None = None,
+    data: dict[str, Any] | None = None,
+    config: AuthleteConfig | None = None,
 ) -> dict[str, Any]:
     """Make a request to the Authlete IdP API."""
+    from ..config import AUTHLETE_IDP_URL
 
-    url = f"{config.idp_url}/api/{endpoint}"
+    if config:
+        base_url = config.idp_url
+        token = config.access_token
+    else:
+        base_url = AUTHLETE_IDP_URL
+        token = access_token
+
+    url = f"{base_url}/api/{endpoint}"
 
     try:
         # Use structured logging with PII masking
         log_request_response(logger, method, f"{url} (IdP API)", request_data=data)
 
-        headers = {"Authorization": f"Bearer {config.access_token}", "Content-Type": "application/json"}
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
         async with httpx.AsyncClient() as client:
             if method.upper() == "GET":

--- a/src/authlete_mcp/config.py
+++ b/src/authlete_mcp/config.py
@@ -7,7 +7,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 # Configuration constants
-AUTHLETE_API_URL = os.getenv("AUTHLETE_API_URL", "https://jp.authlete.com")
+AUTHLETE_API_URL = os.getenv("AUTHLETE_API_URL") or os.getenv("AUTHLETE_BASE_URL") or "https://jp.authlete.com"
 AUTHLETE_IDP_URL = os.getenv("AUTHLETE_IDP_URL", "https://login.authlete.com")
 DEFAULT_API_SERVER_ID = os.getenv("AUTHLETE_API_SERVER_ID", "53285")
 ORGANIZATION_ACCESS_TOKEN = os.getenv("ORGANIZATION_ACCESS_TOKEN", "")
@@ -198,4 +198,10 @@ def check_deprecated_env_vars() -> None:
         logger.warning(
             "AUTHLETE_API_SERVER_ID environment variable is deprecated. "
             "Use the 'list_api_servers' and 'set_api_server' tools instead for dynamic API server selection."
+        )
+
+    if os.getenv("AUTHLETE_BASE_URL"):
+        logger.warning(
+            "AUTHLETE_BASE_URL environment variable is deprecated. "
+            "Use AUTHLETE_API_URL or the API server tools to manage your defaults."
         )

--- a/src/authlete_mcp/config.py
+++ b/src/authlete_mcp/config.py
@@ -1,5 +1,6 @@
 """Configuration for Authlete MCP Server."""
 
+import logging
 import os
 
 from pydantic import BaseModel, Field
@@ -11,6 +12,11 @@ DEFAULT_API_SERVER_ID = os.getenv("AUTHLETE_API_SERVER_ID", "53285")
 ORGANIZATION_ACCESS_TOKEN = os.getenv("ORGANIZATION_ACCESS_TOKEN", "")
 DEFAULT_ORGANIZATION_ID = os.getenv("ORGANIZATION_ID", "")
 
+# Global state for current API server configuration
+_current_api_server: dict | None = None
+
+logger = logging.getLogger(__name__)
+
 
 class AuthleteConfig(BaseModel):
     """Configuration for Authlete API."""
@@ -19,3 +25,100 @@ class AuthleteConfig(BaseModel):
     base_url: str = Field(default=AUTHLETE_API_URL, description="Authlete API URL")
     idp_url: str = Field(default=AUTHLETE_IDP_URL, description="Authlete IdP URL")
     api_server_id: str = Field(default=DEFAULT_API_SERVER_ID, description="API Server ID")
+
+
+def set_current_api_server(api_server_id: int, api_server_url: str, description: str = "") -> None:
+    """Set the current API server configuration for all Authlete API calls."""
+    global _current_api_server
+    _current_api_server = {"id": api_server_id, "url": api_server_url, "description": description}
+    logger.info(f"API server set to: {api_server_url} (ID: {api_server_id})")
+
+
+def get_current_api_server() -> dict | None:
+    """Get the current API server configuration."""
+    return _current_api_server
+
+
+def clear_current_api_server() -> None:
+    """Clear the current API server configuration."""
+    global _current_api_server
+    _current_api_server = None
+    logger.info("API server configuration cleared")
+
+
+async def auto_detect_api_server_from_url() -> dict | None:
+    """Auto-detect API server ID from AUTHLETE_API_URL by querying available servers."""
+    if not ORGANIZATION_ACCESS_TOKEN:
+        return None
+
+    try:
+        from .api.client import make_authlete_idp_request
+
+        response = await make_authlete_idp_request(
+            endpoint="apiserver",
+            method="GET",
+            access_token=ORGANIZATION_ACCESS_TOKEN,
+        )
+
+        if not response or len(response) == 0:
+            return None
+
+        # Find server that matches AUTHLETE_API_URL
+        target_url = AUTHLETE_API_URL.rstrip("/")
+        for server in response:
+            server_url = server["apiServerUrl"].rstrip("/")
+            if server_url == target_url:
+                return {"id": server["id"], "url": server["apiServerUrl"], "description": server.get("description", "")}
+
+        return None
+
+    except Exception as e:
+        logger.error(f"Failed to auto-detect API server: {e}")
+        return None
+
+
+async def ensure_api_server_configured() -> str | None:
+    """Ensure API server is configured, auto-detect if possible, or return error message."""
+    current_server = get_current_api_server()
+
+    if current_server:
+        return None  # Already configured
+
+    # Try to auto-detect from AUTHLETE_API_URL
+    detected_server = await auto_detect_api_server_from_url()
+    if detected_server:
+        set_current_api_server(
+            api_server_id=detected_server["id"],
+            api_server_url=detected_server["url"],
+            description=detected_server.get("description", ""),
+        )
+        logger.info(f"Auto-detected API server from AUTHLETE_API_URL: {detected_server['url']}")
+        return None  # Successfully configured
+
+    # Cannot auto-detect, return error message
+    return (
+        "No API server is currently configured. "
+        "Please use the 'list_api_servers' tool to see available options, "
+        "then use 'set_api_server' to configure your preferred API server."
+    )
+
+
+def get_api_server_url() -> str | None:
+    """Get the current API server URL, or None if not configured."""
+    current_server = get_current_api_server()
+    return current_server["url"] if current_server else None
+
+
+def get_api_server_id() -> int | None:
+    """Get the current API server ID, or None if not configured."""
+    current_server = get_current_api_server()
+    return current_server["id"] if current_server else None
+
+
+def check_deprecated_env_vars() -> None:
+    """Check for deprecated environment variables and warn users."""
+    if os.getenv("AUTHLETE_API_SERVER_ID"):
+        logger.warning(
+            "AUTHLETE_API_SERVER_ID environment variable is deprecated. "
+            "Use the 'list_api_servers' and 'set_api_server' tools instead for dynamic API server selection."
+        )

--- a/src/authlete_mcp/config.py
+++ b/src/authlete_mcp/config.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -101,6 +102,82 @@ async def ensure_api_server_configured() -> str | None:
         "Please use the 'list_api_servers' tool to see available options, "
         "then use 'set_api_server' to configure your preferred API server."
     )
+
+
+async def configure_api_server_by_id(
+    api_server_id: str | int,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Configure the current API server using an explicit server ID."""
+
+    if not ORGANIZATION_ACCESS_TOKEN:
+        return None, "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
+
+    try:
+        from .api.client import make_authlete_idp_request
+
+        response = await make_authlete_idp_request(
+            endpoint="apiserver",
+            method="GET",
+            access_token=ORGANIZATION_ACCESS_TOKEN,
+        )
+    except Exception as exc:
+        logger.error(f"Failed to fetch API servers: {exc}")
+        return None, f"Error setting API server: {exc}"
+
+    if not response:
+        return None, "Error: No API servers found for this organization"
+
+    target_server: dict[str, Any] | None = None
+    available_ids: list[str] = []
+    for server in response:
+        server_id = str(server.get("id"))
+        if server_id:
+            available_ids.append(server_id)
+        if server_id == str(api_server_id):
+            target_server = server
+
+    if not target_server:
+        available_ids.sort()
+        available = ", ".join(available_ids)
+        return (
+            None,
+            f"Error: API server with ID '{api_server_id}' not found. Available API server IDs: {available}",
+        )
+
+    set_current_api_server(
+        api_server_id=int(target_server["id"]),
+        api_server_url=target_server.get("apiServerUrl", ""),
+        description=target_server.get("description", ""),
+    )
+
+    return target_server, None
+
+
+async def ensure_api_server_ready(
+    explicit_api_server_id: str | int | None = None,
+) -> tuple[int | None, str | None]:
+    """Ensure an API server ID is available, honoring explicit overrides."""
+
+    if explicit_api_server_id not in (None, ""):
+        server_info, error = await configure_api_server_by_id(explicit_api_server_id)
+        if error:
+            return None, error
+        return int(server_info["id"]), None
+
+    error_msg = await ensure_api_server_configured()
+    if error_msg:
+        if DEFAULT_API_SERVER_ID:
+            server_info, error = await configure_api_server_by_id(DEFAULT_API_SERVER_ID)
+            if error:
+                return None, error
+            return int(server_info["id"]), None
+        return None, error_msg
+
+    api_server_id = get_api_server_id()
+    if api_server_id is None:
+        return None, "Unable to determine API server ID"
+
+    return int(api_server_id), None
 
 
 def get_api_server_url() -> str | None:

--- a/src/authlete_mcp/server.py
+++ b/src/authlete_mcp/server.py
@@ -4,6 +4,7 @@ import logging
 
 from mcp.server.fastmcp import FastMCP
 
+from .config import check_deprecated_env_vars
 from .tools import (
     client_tools,
     jose_tools,
@@ -70,10 +71,15 @@ mcp.tool()(search_tools.get_schema_detail)
 
 # Utility Tools
 mcp.tool()(utility_tools.generate_jwks)
+mcp.tool()(utility_tools.list_api_servers)
+mcp.tool()(utility_tools.set_api_server)
+mcp.tool()(utility_tools.get_current_api_server_info)
 
 
 def run():
     """Run the MCP server."""
+    # Check for deprecated environment variables
+    check_deprecated_env_vars()
     mcp.run()
 
 

--- a/src/authlete_mcp/tools/service_tools.py
+++ b/src/authlete_mcp/tools/service_tools.py
@@ -5,7 +5,7 @@ import json
 from mcp.server.fastmcp import Context
 
 from ..api.client import make_authlete_idp_request, make_authlete_request
-from ..config import DEFAULT_ORGANIZATION_ID, ORGANIZATION_ACCESS_TOKEN, AuthleteConfig, get_api_server_id
+from ..config import DEFAULT_ORGANIZATION_ID, ORGANIZATION_ACCESS_TOKEN, AuthleteConfig, ensure_api_server_ready
 
 
 async def create_service(name: str, description: str = "", ctx: Context = None) -> str:
@@ -27,17 +27,15 @@ async def create_service(name: str, description: str = "", ctx: Context = None) 
 
     # Get current API server ID using dynamic determination
     try:
-        from ..config import ensure_api_server_configured
-
-        error_msg = await ensure_api_server_configured()
-        if error_msg:
-            return error_msg
-
-        current_api_server_id = get_api_server_id()
-        if not current_api_server_id:
-            return "Error: Unable to determine API server ID"
+        current_api_server_id, error_msg = await ensure_api_server_ready()
     except Exception as e:
         return f"Error configuring API server: {str(e)}"
+
+    if error_msg:
+        return error_msg
+
+    if current_api_server_id is None:
+        return "Error: Unable to determine API server ID"
 
     # Create service configuration for IdP API (without number, serviceOwnerNumber, apiKey, cluster)
     service_data = {
@@ -155,7 +153,7 @@ async def create_service_detailed(
 
     Args:
         service_config: JSON string containing service configuration following Authlete API service schema
-        apiServerId: API Server ID (required) - use list_api_servers tool to see available options
+        apiServerId: API Server ID override. When omitted, uses the configured or auto-detected server.
     """
     if not ORGANIZATION_ACCESS_TOKEN:
         return "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
@@ -163,14 +161,16 @@ async def create_service_detailed(
     if not DEFAULT_ORGANIZATION_ID:
         return "Error: ORGANIZATION_ID environment variable must be set"
 
-    if not apiServerId:
-        return (
-            "Error: apiServerId parameter is required. "
-            "Please use the 'list_api_servers' tool to see available API servers and their IDs, "
-            "then specify the desired apiServerId when calling this function."
-        )
+    try:
+        resolved_api_server_id, error_msg = await ensure_api_server_ready(apiServerId)
+    except Exception as e:
+        return f"Error configuring API server: {str(e)}"
 
-    config = AuthleteConfig(access_token=ORGANIZATION_ACCESS_TOKEN)
+    if error_msg:
+        return error_msg
+
+    if resolved_api_server_id is None:
+        return "Error: Unable to determine API server ID"
 
     try:
         # Parse service configuration JSON
@@ -181,13 +181,18 @@ async def create_service_detailed(
     try:
         # Create the IdP API request payload
         data = {
-            "apiServerId": int(apiServerId),
+            "apiServerId": int(resolved_api_server_id),
             "organizationId": int(DEFAULT_ORGANIZATION_ID),
             "service": service_dict,
         }
 
         # Send request to Authlete IdP API
-        result = await make_authlete_idp_request("POST", "service", config, data)
+        result = await make_authlete_idp_request(
+            endpoint="service",
+            method="POST",
+            access_token=ORGANIZATION_ACCESS_TOKEN,
+            data=data,
+        )
 
         return json.dumps(result, indent=2)
 
@@ -383,7 +388,7 @@ async def delete_service(service_id: str, apiServerId: str = "", ctx: Context = 
 
     Args:
         service_id: Service ID (apiKey) to delete
-        apiServerId: API Server ID (required) - use list_api_servers tool to see available options
+        apiServerId: API Server ID override. When omitted, uses the configured or auto-detected server.
     """
     if not ORGANIZATION_ACCESS_TOKEN:
         return "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
@@ -391,24 +396,30 @@ async def delete_service(service_id: str, apiServerId: str = "", ctx: Context = 
     if not DEFAULT_ORGANIZATION_ID:
         return "Error: ORGANIZATION_ID environment variable must be set"
 
-    if not apiServerId:
-        return (
-            "Error: apiServerId parameter is required. "
-            "Please use the 'list_api_servers' tool to see available API servers and their IDs, "
-            "then specify the desired apiServerId when calling this function."
-        )
+    try:
+        resolved_api_server_id, error_msg = await ensure_api_server_ready(apiServerId)
+    except Exception as e:
+        return f"Error configuring API server: {str(e)}"
 
-    config = AuthleteConfig(access_token=ORGANIZATION_ACCESS_TOKEN)
+    if error_msg:
+        return error_msg
 
-    # Try with environment variable values first
+    if resolved_api_server_id is None:
+        return "Error: Unable to determine API server ID"
+
     data = {
         "serviceId": int(service_id),
-        "apiServerId": int(apiServerId),
+        "apiServerId": int(resolved_api_server_id),
         "organizationId": int(DEFAULT_ORGANIZATION_ID),
     }
 
     try:
-        result = await make_authlete_idp_request("POST", "service/remove", config, data)
+        result = await make_authlete_idp_request(
+            endpoint="service/remove",
+            method="POST",
+            access_token=ORGANIZATION_ACCESS_TOKEN,
+            data=data,
+        )
         return json.dumps(result, indent=2)
     except Exception as e:
         return f"Error deleting service: {str(e)}"

--- a/src/authlete_mcp/tools/service_tools.py
+++ b/src/authlete_mcp/tools/service_tools.py
@@ -5,7 +5,7 @@ import json
 from mcp.server.fastmcp import Context
 
 from ..api.client import make_authlete_idp_request, make_authlete_request
-from ..config import DEFAULT_ORGANIZATION_ID, ORGANIZATION_ACCESS_TOKEN, AuthleteConfig
+from ..config import DEFAULT_ORGANIZATION_ID, ORGANIZATION_ACCESS_TOKEN, AuthleteConfig, get_api_server_id
 
 
 async def create_service(name: str, description: str = "", ctx: Context = None) -> str:
@@ -14,6 +14,10 @@ async def create_service(name: str, description: str = "", ctx: Context = None) 
     Args:
         name: Service name
         description: Service description
+
+    Note:
+        This function uses the currently configured API server. If no API server is configured,
+        it will attempt to auto-detect from AUTHLETE_API_URL or prompt you to set one.
     """
     if not ORGANIZATION_ACCESS_TOKEN:
         return "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
@@ -21,7 +25,19 @@ async def create_service(name: str, description: str = "", ctx: Context = None) 
     if not DEFAULT_ORGANIZATION_ID:
         return "Error: ORGANIZATION_ID environment variable must be set"
 
-    config = AuthleteConfig(access_token=ORGANIZATION_ACCESS_TOKEN)
+    # Get current API server ID using dynamic determination
+    try:
+        from ..config import ensure_api_server_configured
+
+        error_msg = await ensure_api_server_configured()
+        if error_msg:
+            return error_msg
+
+        current_api_server_id = get_api_server_id()
+        if not current_api_server_id:
+            return "Error: Unable to determine API server ID"
+    except Exception as e:
+        return f"Error configuring API server: {str(e)}"
 
     # Create service configuration for IdP API (without number, serviceOwnerNumber, apiKey, cluster)
     service_data = {
@@ -116,13 +132,15 @@ async def create_service(name: str, description: str = "", ctx: Context = None) 
     }
 
     data = {
-        "apiServerId": int(config.api_server_id),
+        "apiServerId": current_api_server_id,
         "organizationId": int(DEFAULT_ORGANIZATION_ID),
         "service": service_data,
     }
 
     try:
-        result = await make_authlete_idp_request("POST", "service", config, data)
+        result = await make_authlete_idp_request(
+            endpoint="service", method="POST", access_token=ORGANIZATION_ACCESS_TOKEN, data=data
+        )
         return json.dumps(result, indent=2)
     except Exception as e:
         return f"Error creating service: {str(e)}"
@@ -130,18 +148,27 @@ async def create_service(name: str, description: str = "", ctx: Context = None) 
 
 async def create_service_detailed(
     service_config: str,
+    apiServerId: str = "",
     ctx: Context = None,
 ) -> str:
     """Create a new Authlete service via IdP with detailed configuration.
 
     Args:
         service_config: JSON string containing service configuration following Authlete API service schema
+        apiServerId: API Server ID (required) - use list_api_servers tool to see available options
     """
     if not ORGANIZATION_ACCESS_TOKEN:
         return "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
 
     if not DEFAULT_ORGANIZATION_ID:
         return "Error: ORGANIZATION_ID environment variable must be set"
+
+    if not apiServerId:
+        return (
+            "Error: apiServerId parameter is required. "
+            "Please use the 'list_api_servers' tool to see available API servers and their IDs, "
+            "then specify the desired apiServerId when calling this function."
+        )
 
     config = AuthleteConfig(access_token=ORGANIZATION_ACCESS_TOKEN)
 
@@ -154,7 +181,7 @@ async def create_service_detailed(
     try:
         # Create the IdP API request payload
         data = {
-            "apiServerId": int(config.api_server_id),
+            "apiServerId": int(apiServerId),
             "organizationId": int(DEFAULT_ORGANIZATION_ID),
             "service": service_dict,
         }
@@ -351,11 +378,12 @@ async def update_service(service_data: str, service_api_key: str = "", ctx: Cont
         return f"Error updating service: {str(e)}"
 
 
-async def delete_service(service_id: str, ctx: Context = None) -> str:
+async def delete_service(service_id: str, apiServerId: str = "", ctx: Context = None) -> str:
     """Delete an Authlete service via IdP.
 
     Args:
         service_id: Service ID (apiKey) to delete
+        apiServerId: API Server ID (required) - use list_api_servers tool to see available options
     """
     if not ORGANIZATION_ACCESS_TOKEN:
         return "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
@@ -363,12 +391,19 @@ async def delete_service(service_id: str, ctx: Context = None) -> str:
     if not DEFAULT_ORGANIZATION_ID:
         return "Error: ORGANIZATION_ID environment variable must be set"
 
+    if not apiServerId:
+        return (
+            "Error: apiServerId parameter is required. "
+            "Please use the 'list_api_servers' tool to see available API servers and their IDs, "
+            "then specify the desired apiServerId when calling this function."
+        )
+
     config = AuthleteConfig(access_token=ORGANIZATION_ACCESS_TOKEN)
 
     # Try with environment variable values first
     data = {
         "serviceId": int(service_id),
-        "apiServerId": int(config.api_server_id),
+        "apiServerId": int(apiServerId),
         "organizationId": int(DEFAULT_ORGANIZATION_ID),
     }
 

--- a/src/authlete_mcp/tools/utility_tools.py
+++ b/src/authlete_mcp/tools/utility_tools.py
@@ -5,6 +5,9 @@ import json
 import httpx
 from mcp.server.fastmcp import Context
 
+from ..api.client import make_authlete_idp_request
+from ..config import ORGANIZATION_ACCESS_TOKEN, get_current_api_server, set_current_api_server
+
 
 async def generate_jwks(
     kty: str = "rsa",
@@ -86,3 +89,120 @@ async def generate_jwks(
         return f"Error: Invalid JSON response - {str(e)}"
     except Exception as e:
         return f"Error generating JWKS: {str(e)}"
+
+
+async def list_api_servers() -> str:
+    """List all API servers available to the organization token.
+
+    This function dynamically retrieves the list of API servers and their IDs
+    from the Authlete IdP API, eliminating the need to hardcode apiServerId
+    in environment variables.
+
+    Returns:
+        JSON string containing the list of API servers with their IDs and URLs
+    """
+    if not ORGANIZATION_ACCESS_TOKEN:
+        return "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
+
+    try:
+        response = await make_authlete_idp_request(
+            endpoint="apiserver",
+            method="GET",
+            access_token=ORGANIZATION_ACCESS_TOKEN,
+        )
+
+        return json.dumps(response, indent=2)
+
+    except Exception as e:
+        return f"Error listing API servers: {str(e)}"
+
+
+async def set_api_server(apiServerId: str, ctx: Context = None) -> str:
+    """Set the current API server for all Authlete API calls.
+
+    This function sets the API server to be used for all subsequent Authlete API calls.
+    You must call this function before using other Authlete API tools.
+
+    Args:
+        apiServerId: API Server ID to set as current - use list_api_servers to see available options
+
+    Returns:
+        JSON string confirming the API server has been set
+    """
+    if not ORGANIZATION_ACCESS_TOKEN:
+        return "Error: ORGANIZATION_ACCESS_TOKEN environment variable not set"
+
+    if not apiServerId:
+        return (
+            "Error: apiServerId parameter is required. "
+            "Please use the 'list_api_servers' tool to see available API servers and their IDs, "
+            "then specify the desired apiServerId."
+        )
+
+    try:
+        # Get the list of available API servers to validate the ID and get the URL
+        response = await make_authlete_idp_request(
+            endpoint="apiserver",
+            method="GET",
+            access_token=ORGANIZATION_ACCESS_TOKEN,
+        )
+
+        if not response or len(response) == 0:
+            return "Error: No API servers found for this organization"
+
+        # Find the server with the specified ID
+        target_server = None
+        for server in response:
+            if str(server["id"]) == str(apiServerId):
+                target_server = server
+                break
+
+        if not target_server:
+            available_ids = [str(server["id"]) for server in response]
+            return (
+                f"Error: API server with ID '{apiServerId}' not found. "
+                f"Available API server IDs: {', '.join(available_ids)}"
+            )
+
+        # Set the current API server
+        set_current_api_server(
+            api_server_id=target_server["id"],
+            api_server_url=target_server["apiServerUrl"],
+            description=target_server.get("description", ""),
+        )
+
+        result = {
+            "message": "API server set successfully",
+            "apiServerId": target_server["id"],
+            "apiServerUrl": target_server["apiServerUrl"],
+            "description": target_server.get("description", ""),
+        }
+
+        return json.dumps(result, indent=2)
+
+    except Exception as e:
+        return f"Error setting API server: {str(e)}"
+
+
+async def get_current_api_server_info(ctx: Context = None) -> str:
+    """Get the currently configured API server information.
+
+    Returns:
+        JSON string containing current API server configuration or instructions to set one
+    """
+    current_server = get_current_api_server()
+
+    if current_server:
+        result = {
+            "message": "Current API server configuration",
+            "apiServerId": current_server["id"],
+            "apiServerUrl": current_server["url"],
+            "description": current_server.get("description", ""),
+        }
+        return json.dumps(result, indent=2)
+    else:
+        return (
+            "No API server is currently configured. "
+            "Please use the 'list_api_servers' tool to see available options, "
+            "then use 'set_api_server' to configure your preferred API server."
+        )

--- a/src/authlete_mcp/tools/utility_tools.py
+++ b/src/authlete_mcp/tools/utility_tools.py
@@ -6,7 +6,7 @@ import httpx
 from mcp.server.fastmcp import Context
 
 from ..api.client import make_authlete_idp_request
-from ..config import ORGANIZATION_ACCESS_TOKEN, get_current_api_server, set_current_api_server
+from ..config import ORGANIZATION_ACCESS_TOKEN, configure_api_server_by_id, get_current_api_server
 
 
 async def generate_jwks(
@@ -139,49 +139,18 @@ async def set_api_server(apiServerId: str, ctx: Context = None) -> str:
             "then specify the desired apiServerId."
         )
 
-    try:
-        # Get the list of available API servers to validate the ID and get the URL
-        response = await make_authlete_idp_request(
-            endpoint="apiserver",
-            method="GET",
-            access_token=ORGANIZATION_ACCESS_TOKEN,
-        )
+    server_info, error = await configure_api_server_by_id(apiServerId)
+    if error:
+        return error
 
-        if not response or len(response) == 0:
-            return "Error: No API servers found for this organization"
+    result = {
+        "message": "API server set successfully",
+        "apiServerId": server_info["id"],
+        "apiServerUrl": server_info.get("apiServerUrl", ""),
+        "description": server_info.get("description", ""),
+    }
 
-        # Find the server with the specified ID
-        target_server = None
-        for server in response:
-            if str(server["id"]) == str(apiServerId):
-                target_server = server
-                break
-
-        if not target_server:
-            available_ids = [str(server["id"]) for server in response]
-            return (
-                f"Error: API server with ID '{apiServerId}' not found. "
-                f"Available API server IDs: {', '.join(available_ids)}"
-            )
-
-        # Set the current API server
-        set_current_api_server(
-            api_server_id=target_server["id"],
-            api_server_url=target_server["apiServerUrl"],
-            description=target_server.get("description", ""),
-        )
-
-        result = {
-            "message": "API server set successfully",
-            "apiServerId": target_server["id"],
-            "apiServerUrl": target_server["apiServerUrl"],
-            "description": target_server.get("description", ""),
-        }
-
-        return json.dumps(result, indent=2)
-
-    except Exception as e:
-        return f"Error setting API server: {str(e)}"
+    return json.dumps(result, indent=2)
 
 
 async def get_current_api_server_info(ctx: Context = None) -> str:

--- a/tests/test_api_server_selection.py
+++ b/tests/test_api_server_selection.py
@@ -7,6 +7,7 @@ import pytest
 ENV_KEYS = [
     "AUTHLETE_API_SERVER_ID",
     "AUTHLETE_API_URL",
+    "AUTHLETE_BASE_URL",
     "ORGANIZATION_ACCESS_TOKEN",
     "ORGANIZATION_ID",
 ]
@@ -74,6 +75,38 @@ async def test_env_default_api_server_used(monkeypatch: pytest.MonkeyPatch):
     current = config.get_current_api_server()
     assert current == {"id": 12345, "url": "https://env.example", "description": ""}
     assert calls and calls[0][0] == "apiserver"
+
+
+@pytest.mark.asyncio
+async def test_env_base_url_fallback(monkeypatch: pytest.MonkeyPatch):
+    config, _, _ = reload_modules(
+        monkeypatch,
+        {
+            "AUTHLETE_BASE_URL": "https://env.example",
+            "ORGANIZATION_ACCESS_TOKEN": "token",
+            "ORGANIZATION_ID": "999",
+        },
+    )
+
+    import src.authlete_mcp.api.client as api_client
+
+    async def fake_make_authlete_idp_request(
+        endpoint: str,
+        method: str = "GET",
+        access_token: str | None = None,
+        data: dict[str, Any] | None = None,
+        config: Any = None,
+    ) -> Any:
+        assert endpoint == "apiserver"
+        return [{"id": 777, "apiServerUrl": "https://env.example"}]
+
+    monkeypatch.setattr(api_client, "make_authlete_idp_request", fake_make_authlete_idp_request)
+
+    api_server_id, error = await config.ensure_api_server_ready()
+
+    assert error is None
+    assert api_server_id == 777
+    assert config.get_current_api_server()["url"] == "https://env.example"
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_server_selection.py
+++ b/tests/test_api_server_selection.py
@@ -1,0 +1,228 @@
+import importlib
+import json
+from typing import Any
+
+import pytest
+
+ENV_KEYS = [
+    "AUTHLETE_API_SERVER_ID",
+    "AUTHLETE_API_URL",
+    "ORGANIZATION_ACCESS_TOKEN",
+    "ORGANIZATION_ID",
+]
+
+
+def reload_modules(monkeypatch: pytest.MonkeyPatch, env: dict[str, str | None]):
+    """Reload config and tool modules with the specified environment overrides."""
+    for key in ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+    for key, value in env.items():
+        if value is not None:
+            monkeypatch.setenv(key, value)
+
+    import src.authlete_mcp.config as config_module
+    import src.authlete_mcp.tools.service_tools as service_module
+    import src.authlete_mcp.tools.utility_tools as utility_module
+
+    config = importlib.reload(config_module)
+    utility_tools = importlib.reload(utility_module)
+    service_tools = importlib.reload(service_module)
+    config.clear_current_api_server()
+    return config, utility_tools, service_tools
+
+
+@pytest.mark.asyncio
+async def test_env_default_api_server_used(monkeypatch: pytest.MonkeyPatch):
+    config, _, _ = reload_modules(
+        monkeypatch,
+        {
+            "AUTHLETE_API_SERVER_ID": "12345",
+            "AUTHLETE_API_URL": "https://env.example",
+            "ORGANIZATION_ACCESS_TOKEN": "token",
+            "ORGANIZATION_ID": "999",
+        },
+    )
+
+    import src.authlete_mcp.api.client as api_client
+
+    calls: list[tuple[str, str, Any]] = []
+
+    async def fake_make_authlete_idp_request(
+        endpoint: str,
+        method: str = "GET",
+        access_token: str | None = None,
+        data: dict[str, Any] | None = None,
+        config: Any = None,
+    ) -> Any:
+        calls.append((endpoint, method, data))
+        if endpoint == "apiserver" and method == "GET":
+            return [
+                {
+                    "id": 12345,
+                    "apiServerUrl": "https://env.example",
+                }
+            ]
+        raise AssertionError(f"Unexpected call: {endpoint} {method}")
+
+    monkeypatch.setattr(api_client, "make_authlete_idp_request", fake_make_authlete_idp_request)
+
+    api_server_id, error = await config.ensure_api_server_ready()
+
+    assert error is None
+    assert api_server_id == 12345
+    current = config.get_current_api_server()
+    assert current == {"id": 12345, "url": "https://env.example", "description": ""}
+    assert calls and calls[0][0] == "apiserver"
+
+
+@pytest.mark.asyncio
+async def test_set_api_server_overrides_environment(monkeypatch: pytest.MonkeyPatch):
+    config, utility_tools, _ = reload_modules(
+        monkeypatch,
+        {
+            "AUTHLETE_API_SERVER_ID": "12345",
+            "AUTHLETE_API_URL": "https://env.example",
+            "ORGANIZATION_ACCESS_TOKEN": "token",
+            "ORGANIZATION_ID": "999",
+        },
+    )
+
+    import src.authlete_mcp.api.client as api_client
+
+    async def fake_make_authlete_idp_request(
+        endpoint: str,
+        method: str = "GET",
+        access_token: str | None = None,
+        data: dict[str, Any] | None = None,
+        config: Any = None,
+    ) -> Any:
+        if endpoint == "apiserver" and method == "GET":
+            return [
+                {"id": 12345, "apiServerUrl": "https://env.example"},
+                {"id": 67890, "apiServerUrl": "https://override.example"},
+            ]
+        raise AssertionError(f"Unexpected call: {endpoint} {method}")
+
+    monkeypatch.setattr(api_client, "make_authlete_idp_request", fake_make_authlete_idp_request)
+
+    result = await utility_tools.set_api_server("67890")
+    payload = json.loads(result)
+    assert payload["apiServerId"] == 67890
+    assert payload["apiServerUrl"] == "https://override.example"
+
+    api_server_id, error = await config.ensure_api_server_ready()
+    assert error is None
+    assert api_server_id == 67890
+    current = config.get_current_api_server()
+    assert current == {"id": 67890, "url": "https://override.example", "description": ""}
+
+
+@pytest.mark.asyncio
+async def test_tools_fail_without_environment_or_override(monkeypatch: pytest.MonkeyPatch):
+    config, _, service_tools = reload_modules(
+        monkeypatch,
+        {
+            "AUTHLETE_API_SERVER_ID": "",
+            "AUTHLETE_API_URL": "",
+            "ORGANIZATION_ACCESS_TOKEN": "token",
+            "ORGANIZATION_ID": "999",
+        },
+    )
+
+    error_message = (
+        "No API server is currently configured. Please use the 'list_api_servers' tool to see available options, "
+        "then use 'set_api_server' to configure your preferred API server."
+    )
+
+    async def fake_ensure_api_server_configured() -> str:
+        return error_message
+
+    monkeypatch.setattr(config, "ensure_api_server_configured", fake_ensure_api_server_configured)
+
+    async def fail_make_authlete_idp_request(*args, **kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("IDP request should not be invoked when configuration fails")
+
+    monkeypatch.setattr(service_tools, "make_authlete_idp_request", fail_make_authlete_idp_request)
+
+    create_response = await service_tools.create_service("pytest-service", "desc")
+    assert create_response == error_message
+
+    detailed_response = await service_tools.create_service_detailed("{}")
+    assert detailed_response == error_message
+
+    delete_response = await service_tools.delete_service("12345")
+    assert delete_response == error_message
+
+
+@pytest.mark.asyncio
+async def test_tools_succeed_after_setting_api_server(monkeypatch: pytest.MonkeyPatch):
+    config, utility_tools, service_tools = reload_modules(
+        monkeypatch,
+        {
+            "AUTHLETE_API_SERVER_ID": "",
+            "AUTHLETE_API_URL": "",
+            "ORGANIZATION_ACCESS_TOKEN": "token",
+            "ORGANIZATION_ID": "999",
+        },
+    )
+
+    import src.authlete_mcp.api.client as api_client
+
+    async def fake_make_authlete_idp_request_config(
+        endpoint: str,
+        method: str = "GET",
+        access_token: str | None = None,
+        data: dict[str, Any] | None = None,
+        config: Any = None,
+    ) -> Any:
+        if endpoint == "apiserver" and method == "GET":
+            return [{"id": 777, "apiServerUrl": "https://manual.example"}]
+        raise AssertionError(f"Unexpected config call: {endpoint} {method}")
+
+    monkeypatch.setattr(api_client, "make_authlete_idp_request", fake_make_authlete_idp_request_config)
+
+    service_calls: list[tuple[str, str, dict[str, Any] | None]] = []
+
+    async def fake_make_authlete_idp_request_service(
+        endpoint: str,
+        method: str = "GET",
+        access_token: str | None = None,
+        data: dict[str, Any] | None = None,
+        config: Any = None,
+    ) -> Any:
+        service_calls.append((endpoint, method, data))
+        if endpoint == "service" and method == "POST":
+            assert data is not None
+            assert data["apiServerId"] == 777
+            return {"apiKey": 555, "message": "Service created"}
+        if endpoint == "service/remove" and method == "POST":
+            assert data is not None
+            assert data["apiServerId"] == 777
+            return {"message": "Service deleted successfully"}
+        raise AssertionError(f"Unexpected service call: {endpoint} {method}")
+
+    monkeypatch.setattr(service_tools, "make_authlete_idp_request", fake_make_authlete_idp_request_service)
+
+    result = await utility_tools.set_api_server("777")
+    payload = json.loads(result)
+    assert payload["apiServerId"] == 777
+
+    api_server_id, error = await config.ensure_api_server_ready()
+    assert error is None
+    assert api_server_id == 777
+
+    create_response = await service_tools.create_service("pytest-service", "desc")
+    create_payload = json.loads(create_response)
+    assert create_payload["apiKey"] == 555
+
+    detailed_body = json.dumps({"serviceName": "pytest-detailed"})
+    detailed_response = await service_tools.create_service_detailed(detailed_body, apiServerId="")
+    detailed_payload = json.loads(detailed_response)
+    assert detailed_payload["apiKey"] == 555
+
+    delete_response = await service_tools.delete_service("12345")
+    delete_payload = json.loads(delete_response)
+    assert delete_payload["message"] == "Service deleted successfully"
+
+    assert {call[0] for call in service_calls} == {"service", "service/remove"}

--- a/tests/test_client_operations.py
+++ b/tests/test_client_operations.py
@@ -297,6 +297,9 @@ async def test_client_secret_operations_with_service_api_key():
         async with ClientSession(read_stream, write_stream) as session:
             await session.initialize()
 
+            # Set API server to jp.authlete.com (ID: 53285)
+            await session.call_tool("set_api_server", {"apiServerId": "53285"})
+
             try:
                 # 1. テスト用サービスを作成
                 service_result = await session.call_tool(
@@ -460,6 +463,9 @@ async def test_client_deletion_with_service_api_key():
     async with stdio_client(server_params) as (read_stream, write_stream):
         async with ClientSession(read_stream, write_stream) as session:
             await session.initialize()
+
+            # Set API server to jp.authlete.com (ID: 53285)
+            await session.call_tool("set_api_server", {"apiServerId": "53285"})
 
             try:
                 # 1. テスト用サービスを作成

--- a/tests/test_dynamic_api_server.py
+++ b/tests/test_dynamic_api_server.py
@@ -172,9 +172,7 @@ async def test_set_api_server_function():
     mock_response = [{"id": 53285, "apiServerUrl": "https://jp.authlete.com", "description": "JP API Server"}]
 
     with patch.dict(os.environ, {"ORGANIZATION_ACCESS_TOKEN": "test_token"}):
-        with patch(
-            "src.authlete_mcp.tools.utility_tools.make_authlete_idp_request", new_callable=AsyncMock
-        ) as mock_request:
+        with patch("src.authlete_mcp.api.client.make_authlete_idp_request", new_callable=AsyncMock) as mock_request:
             mock_request.return_value = mock_response
 
             # Clear any existing state
@@ -198,9 +196,7 @@ async def test_set_api_server_invalid_id():
     mock_response = [{"id": 53285, "apiServerUrl": "https://jp.authlete.com", "description": "JP API Server"}]
 
     with patch.dict(os.environ, {"ORGANIZATION_ACCESS_TOKEN": "test_token"}):
-        with patch(
-            "src.authlete_mcp.tools.utility_tools.make_authlete_idp_request", new_callable=AsyncMock
-        ) as mock_request:
+        with patch("src.authlete_mcp.api.client.make_authlete_idp_request", new_callable=AsyncMock) as mock_request:
             mock_request.return_value = mock_response
 
             result = await set_api_server("99999")

--- a/tests/test_dynamic_api_server.py
+++ b/tests/test_dynamic_api_server.py
@@ -2,11 +2,31 @@
 
 import json
 import os
+from contextlib import ExitStack
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from src.authlete_mcp import config
+
+
+def _patch_org_env(org_id: str = "12345"):
+    """Return patches that align module-level constants with test credentials."""
+
+    return (
+        patch.dict(
+            os.environ,
+            {
+                "ORGANIZATION_ACCESS_TOKEN": "test_token",
+                "ORGANIZATION_ID": org_id,
+            },
+        ),
+        patch("src.authlete_mcp.config.ORGANIZATION_ACCESS_TOKEN", "test_token"),
+        patch("src.authlete_mcp.config.DEFAULT_ORGANIZATION_ID", org_id),
+        patch("src.authlete_mcp.tools.utility_tools.ORGANIZATION_ACCESS_TOKEN", "test_token"),
+        patch("src.authlete_mcp.tools.service_tools.ORGANIZATION_ACCESS_TOKEN", "test_token"),
+        patch("src.authlete_mcp.tools.service_tools.DEFAULT_ORGANIZATION_ID", org_id),
+    )
 
 
 @pytest.mark.asyncio
@@ -51,17 +71,21 @@ async def test_auto_detect_api_server_from_url():
         {"id": 63294, "apiServerUrl": "https://eu.authlete.com", "description": "EU API Server"},
     ]
 
-    with patch.dict(os.environ, {"ORGANIZATION_ACCESS_TOKEN": "test_token"}):
-        with patch("src.authlete_mcp.config.AUTHLETE_API_URL", "https://jp.authlete.com"):
-            with patch("src.authlete_mcp.api.client.make_authlete_idp_request", new_callable=AsyncMock) as mock_request:
-                mock_request.return_value = mock_response
+    with ExitStack() as stack:
+        for ctx in _patch_org_env():
+            stack.enter_context(ctx)
+        stack.enter_context(patch("src.authlete_mcp.config.AUTHLETE_API_URL", "https://jp.authlete.com"))
+        mock_request = stack.enter_context(
+            patch("src.authlete_mcp.api.client.make_authlete_idp_request", new_callable=AsyncMock)
+        )
+        mock_request.return_value = mock_response
 
-                result = await config.auto_detect_api_server_from_url()
+        result = await config.auto_detect_api_server_from_url()
 
-                assert result is not None
-                assert result["id"] == 53285
-                assert result["url"] == "https://jp.authlete.com"
-                assert result["description"] == "JP API Server"
+        assert result is not None
+        assert result["id"] == 53285
+        assert result["url"] == "https://jp.authlete.com"
+        assert result["description"] == "JP API Server"
 
 
 @pytest.mark.asyncio
@@ -70,15 +94,20 @@ async def test_auto_detect_api_server_not_found():
     """Test auto-detection when API server URL is not found."""
     mock_response = [{"id": 53285, "apiServerUrl": "https://jp.authlete.com", "description": "JP API Server"}]
 
-    with patch.dict(os.environ, {"ORGANIZATION_ACCESS_TOKEN": "test_token"}):
-        # Directly patch the AUTHLETE_API_URL constant in the config module
-        with patch("src.authlete_mcp.config.AUTHLETE_API_URL", "https://completely-different.example.com"):
-            with patch("src.authlete_mcp.api.client.make_authlete_idp_request", new_callable=AsyncMock) as mock_request:
-                mock_request.return_value = mock_response
+    with ExitStack() as stack:
+        for ctx in _patch_org_env():
+            stack.enter_context(ctx)
+        stack.enter_context(
+            patch("src.authlete_mcp.config.AUTHLETE_API_URL", "https://completely-different.example.com")
+        )
+        mock_request = stack.enter_context(
+            patch("src.authlete_mcp.api.client.make_authlete_idp_request", new_callable=AsyncMock)
+        )
+        mock_request.return_value = mock_response
 
-                result = await config.auto_detect_api_server_from_url()
+        result = await config.auto_detect_api_server_from_url()
 
-                assert result is None
+        assert result is None
 
 
 @pytest.mark.asyncio
@@ -98,16 +127,20 @@ async def test_ensure_api_server_configured():
 
     mock_response = [{"id": 53285, "apiServerUrl": "https://jp.authlete.com", "description": "JP API Server"}]
 
-    with patch.dict(os.environ, {"ORGANIZATION_ACCESS_TOKEN": "test_token"}):
-        with patch("src.authlete_mcp.config.AUTHLETE_API_URL", "https://jp.authlete.com"):
-            with patch("src.authlete_mcp.api.client.make_authlete_idp_request", new_callable=AsyncMock) as mock_request:
-                mock_request.return_value = mock_response
+    with ExitStack() as stack:
+        for ctx in _patch_org_env():
+            stack.enter_context(ctx)
+        stack.enter_context(patch("src.authlete_mcp.config.AUTHLETE_API_URL", "https://jp.authlete.com"))
+        mock_request = stack.enter_context(
+            patch("src.authlete_mcp.api.client.make_authlete_idp_request", new_callable=AsyncMock)
+        )
+        mock_request.return_value = mock_response
 
-                result = await config.ensure_api_server_configured()
+        result = await config.ensure_api_server_configured()
 
-                assert result is None  # No error when auto-detection succeeds
-                assert config.get_api_server_id() == 53285
-                assert config.get_api_server_url() == "https://jp.authlete.com"
+        assert result is None  # No error when auto-detection succeeds
+        assert config.get_api_server_id() == 53285
+        assert config.get_api_server_url() == "https://jp.authlete.com"
 
 
 @pytest.mark.asyncio
@@ -116,25 +149,32 @@ async def test_ensure_api_server_configured_no_auto_detect():
     """Test ensure_api_server_configured when auto-detection fails."""
     config.clear_current_api_server()
 
-    with patch.dict(os.environ, {"ORGANIZATION_ACCESS_TOKEN": "test_token"}):
-        with patch("src.authlete_mcp.config.AUTHLETE_API_URL", "https://completely-different.example.com"):
-            with patch("src.authlete_mcp.api.client.make_authlete_idp_request", new_callable=AsyncMock) as mock_request:
-                mock_request.return_value = []  # No servers found
+    with ExitStack() as stack:
+        for ctx in _patch_org_env():
+            stack.enter_context(ctx)
+        stack.enter_context(
+            patch("src.authlete_mcp.config.AUTHLETE_API_URL", "https://completely-different.example.com")
+        )
+        mock_request = stack.enter_context(
+            patch("src.authlete_mcp.api.client.make_authlete_idp_request", new_callable=AsyncMock)
+        )
+        mock_request.return_value = []  # No servers found
 
-                result = await config.ensure_api_server_configured()
+        result = await config.ensure_api_server_configured()
 
-                assert result is not None
-                assert "No API server is currently configured" in result
-                assert "list_api_servers" in result
+        assert result is not None
+        assert "No API server is currently configured" in result
+        assert "list_api_servers" in result
 
 
 def test_check_deprecated_env_vars(caplog):
     """Test deprecated environment variable warning."""
-    with patch.dict(os.environ, {"AUTHLETE_API_SERVER_ID": "12345"}):
+    with patch.dict(os.environ, {"AUTHLETE_API_SERVER_ID": "12345", "AUTHLETE_BASE_URL": "https://old"}):
         config.check_deprecated_env_vars()
 
         assert "deprecated" in caplog.text
         assert "AUTHLETE_API_SERVER_ID" in caplog.text
+        assert "AUTHLETE_BASE_URL" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -148,19 +188,21 @@ async def test_list_api_servers_function():
         {"id": 63294, "apiServerUrl": "https://eu.authlete.com", "description": "EU API Server"},
     ]
 
-    with patch.dict(os.environ, {"ORGANIZATION_ACCESS_TOKEN": "test_token"}):
-        with patch(
-            "src.authlete_mcp.tools.utility_tools.make_authlete_idp_request", new_callable=AsyncMock
-        ) as mock_request:
-            mock_request.return_value = mock_response
+    with ExitStack() as stack:
+        for ctx in _patch_org_env():
+            stack.enter_context(ctx)
+        mock_request = stack.enter_context(
+            patch("src.authlete_mcp.tools.utility_tools.make_authlete_idp_request", new_callable=AsyncMock)
+        )
+        mock_request.return_value = mock_response
 
-            result = await list_api_servers()
+        result = await list_api_servers()
 
-            assert "Error:" not in result
-            response_data = json.loads(result)
-            assert len(response_data) == 2
-            assert response_data[0]["id"] == 53285
-            assert response_data[1]["id"] == 63294
+        assert "Error:" not in result
+        response_data = json.loads(result)
+        assert len(response_data) == 2
+        assert response_data[0]["id"] == 53285
+        assert response_data[1]["id"] == 63294
 
 
 @pytest.mark.asyncio
@@ -171,20 +213,24 @@ async def test_set_api_server_function():
 
     mock_response = [{"id": 53285, "apiServerUrl": "https://jp.authlete.com", "description": "JP API Server"}]
 
-    with patch.dict(os.environ, {"ORGANIZATION_ACCESS_TOKEN": "test_token"}):
-        with patch("src.authlete_mcp.api.client.make_authlete_idp_request", new_callable=AsyncMock) as mock_request:
-            mock_request.return_value = mock_response
+    with ExitStack() as stack:
+        for ctx in _patch_org_env():
+            stack.enter_context(ctx)
+        mock_request = stack.enter_context(
+            patch("src.authlete_mcp.api.client.make_authlete_idp_request", new_callable=AsyncMock)
+        )
+        mock_request.return_value = mock_response
 
-            # Clear any existing state
-            config.clear_current_api_server()
+        # Clear any existing state
+        config.clear_current_api_server()
 
-            result = await set_api_server("53285")
+        result = await set_api_server("53285")
 
-            assert "Error:" not in result
-            response_data = json.loads(result)
-            assert response_data["message"] == "API server set successfully"
-            assert response_data["apiServerId"] == 53285
-            assert response_data["apiServerUrl"] == "https://jp.authlete.com"
+        assert "Error:" not in result
+        response_data = json.loads(result)
+        assert response_data["message"] == "API server set successfully"
+        assert response_data["apiServerId"] == 53285
+        assert response_data["apiServerUrl"] == "https://jp.authlete.com"
 
 
 @pytest.mark.asyncio
@@ -195,14 +241,18 @@ async def test_set_api_server_invalid_id():
 
     mock_response = [{"id": 53285, "apiServerUrl": "https://jp.authlete.com", "description": "JP API Server"}]
 
-    with patch.dict(os.environ, {"ORGANIZATION_ACCESS_TOKEN": "test_token"}):
-        with patch("src.authlete_mcp.api.client.make_authlete_idp_request", new_callable=AsyncMock) as mock_request:
-            mock_request.return_value = mock_response
+    with ExitStack() as stack:
+        for ctx in _patch_org_env():
+            stack.enter_context(ctx)
+        mock_request = stack.enter_context(
+            patch("src.authlete_mcp.api.client.make_authlete_idp_request", new_callable=AsyncMock)
+        )
+        mock_request.return_value = mock_response
 
-            result = await set_api_server("99999")
+        result = await set_api_server("99999")
 
-            assert "API server with ID '99999' not found" in result
-            assert "Available API server IDs: 53285" in result
+        assert "API server with ID '99999' not found" in result
+        assert "Available API server IDs: 53285" in result
 
 
 @pytest.mark.asyncio
@@ -239,14 +289,16 @@ async def test_create_service_with_configured_server():
     # Mock service creation response
     mock_service_response = {"service": {"number": 123456, "serviceName": "Test Service", "apiKey": 987654321}}
 
-    with patch.dict(os.environ, {"ORGANIZATION_ACCESS_TOKEN": "test_token", "ORGANIZATION_ID": "12345"}):
-        with patch(
-            "src.authlete_mcp.tools.service_tools.make_authlete_idp_request", new_callable=AsyncMock
-        ) as mock_request:
-            mock_request.return_value = mock_service_response
+    with ExitStack() as stack:
+        for ctx in _patch_org_env():
+            stack.enter_context(ctx)
+        mock_request = stack.enter_context(
+            patch("src.authlete_mcp.tools.service_tools.make_authlete_idp_request", new_callable=AsyncMock)
+        )
+        mock_request.return_value = mock_service_response
 
-            result = await create_service("Test Service", "Test Description")
+        result = await create_service("Test Service", "Test Description")
 
-            assert "Error:" not in result
-            response_data = json.loads(result)
-            assert response_data["service"]["serviceName"] == "Test Service"
+        assert "Error:" not in result
+        response_data = json.loads(result)
+        assert response_data["service"]["serviceName"] == "Test Service"

--- a/tests/test_dynamic_api_server.py
+++ b/tests/test_dynamic_api_server.py
@@ -1,0 +1,256 @@
+"""Tests for dynamic API server selection functionality."""
+
+import json
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.authlete_mcp import config
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_api_server_state_management():
+    """Test basic API server state management functions."""
+    # Clear any existing state
+    config.clear_current_api_server()
+
+    # Test initial state
+    assert config.get_current_api_server() is None
+    assert config.get_api_server_url() is None
+    assert config.get_api_server_id() is None
+
+    # Test setting API server
+    config.set_current_api_server(
+        api_server_id=12345, api_server_url="https://api.example.com", description="Test API Server"
+    )
+
+    # Test state after setting
+    current = config.get_current_api_server()
+    assert current is not None
+    assert current["id"] == 12345
+    assert current["url"] == "https://api.example.com"
+    assert current["description"] == "Test API Server"
+
+    assert config.get_api_server_url() == "https://api.example.com"
+    assert config.get_api_server_id() == 12345
+
+    # Test clearing state
+    config.clear_current_api_server()
+    assert config.get_current_api_server() is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_auto_detect_api_server_from_url():
+    """Test auto-detection of API server from AUTHLETE_API_URL."""
+    # Mock the make_authlete_idp_request function
+    mock_response = [
+        {"id": 53285, "apiServerUrl": "https://jp.authlete.com", "description": "JP API Server"},
+        {"id": 63294, "apiServerUrl": "https://eu.authlete.com", "description": "EU API Server"},
+    ]
+
+    with patch.dict(os.environ, {"ORGANIZATION_ACCESS_TOKEN": "test_token"}):
+        with patch("src.authlete_mcp.config.AUTHLETE_API_URL", "https://jp.authlete.com"):
+            with patch("src.authlete_mcp.api.client.make_authlete_idp_request", new_callable=AsyncMock) as mock_request:
+                mock_request.return_value = mock_response
+
+                result = await config.auto_detect_api_server_from_url()
+
+                assert result is not None
+                assert result["id"] == 53285
+                assert result["url"] == "https://jp.authlete.com"
+                assert result["description"] == "JP API Server"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_auto_detect_api_server_not_found():
+    """Test auto-detection when API server URL is not found."""
+    mock_response = [{"id": 53285, "apiServerUrl": "https://jp.authlete.com", "description": "JP API Server"}]
+
+    with patch.dict(os.environ, {"ORGANIZATION_ACCESS_TOKEN": "test_token"}):
+        # Directly patch the AUTHLETE_API_URL constant in the config module
+        with patch("src.authlete_mcp.config.AUTHLETE_API_URL", "https://completely-different.example.com"):
+            with patch("src.authlete_mcp.api.client.make_authlete_idp_request", new_callable=AsyncMock) as mock_request:
+                mock_request.return_value = mock_response
+
+                result = await config.auto_detect_api_server_from_url()
+
+                assert result is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_ensure_api_server_configured():
+    """Test ensure_api_server_configured function."""
+    # Clear any existing state
+    config.clear_current_api_server()
+
+    # Test when already configured
+    config.set_current_api_server(12345, "https://api.example.com")
+    result = await config.ensure_api_server_configured()
+    assert result is None  # No error message when already configured
+
+    # Clear state and test auto-detection
+    config.clear_current_api_server()
+
+    mock_response = [{"id": 53285, "apiServerUrl": "https://jp.authlete.com", "description": "JP API Server"}]
+
+    with patch.dict(os.environ, {"ORGANIZATION_ACCESS_TOKEN": "test_token"}):
+        with patch("src.authlete_mcp.config.AUTHLETE_API_URL", "https://jp.authlete.com"):
+            with patch("src.authlete_mcp.api.client.make_authlete_idp_request", new_callable=AsyncMock) as mock_request:
+                mock_request.return_value = mock_response
+
+                result = await config.ensure_api_server_configured()
+
+                assert result is None  # No error when auto-detection succeeds
+                assert config.get_api_server_id() == 53285
+                assert config.get_api_server_url() == "https://jp.authlete.com"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_ensure_api_server_configured_no_auto_detect():
+    """Test ensure_api_server_configured when auto-detection fails."""
+    config.clear_current_api_server()
+
+    with patch.dict(os.environ, {"ORGANIZATION_ACCESS_TOKEN": "test_token"}):
+        with patch("src.authlete_mcp.config.AUTHLETE_API_URL", "https://completely-different.example.com"):
+            with patch("src.authlete_mcp.api.client.make_authlete_idp_request", new_callable=AsyncMock) as mock_request:
+                mock_request.return_value = []  # No servers found
+
+                result = await config.ensure_api_server_configured()
+
+                assert result is not None
+                assert "No API server is currently configured" in result
+                assert "list_api_servers" in result
+
+
+def test_check_deprecated_env_vars(caplog):
+    """Test deprecated environment variable warning."""
+    with patch.dict(os.environ, {"AUTHLETE_API_SERVER_ID": "12345"}):
+        config.check_deprecated_env_vars()
+
+        assert "deprecated" in caplog.text
+        assert "AUTHLETE_API_SERVER_ID" in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_list_api_servers_function():
+    """Test list_api_servers function directly."""
+    from src.authlete_mcp.tools.utility_tools import list_api_servers
+
+    mock_response = [
+        {"id": 53285, "apiServerUrl": "https://jp.authlete.com", "description": "JP API Server"},
+        {"id": 63294, "apiServerUrl": "https://eu.authlete.com", "description": "EU API Server"},
+    ]
+
+    with patch.dict(os.environ, {"ORGANIZATION_ACCESS_TOKEN": "test_token"}):
+        with patch(
+            "src.authlete_mcp.tools.utility_tools.make_authlete_idp_request", new_callable=AsyncMock
+        ) as mock_request:
+            mock_request.return_value = mock_response
+
+            result = await list_api_servers()
+
+            assert "Error:" not in result
+            response_data = json.loads(result)
+            assert len(response_data) == 2
+            assert response_data[0]["id"] == 53285
+            assert response_data[1]["id"] == 63294
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_set_api_server_function():
+    """Test set_api_server function directly."""
+    from src.authlete_mcp.tools.utility_tools import set_api_server
+
+    mock_response = [{"id": 53285, "apiServerUrl": "https://jp.authlete.com", "description": "JP API Server"}]
+
+    with patch.dict(os.environ, {"ORGANIZATION_ACCESS_TOKEN": "test_token"}):
+        with patch(
+            "src.authlete_mcp.tools.utility_tools.make_authlete_idp_request", new_callable=AsyncMock
+        ) as mock_request:
+            mock_request.return_value = mock_response
+
+            # Clear any existing state
+            config.clear_current_api_server()
+
+            result = await set_api_server("53285")
+
+            assert "Error:" not in result
+            response_data = json.loads(result)
+            assert response_data["message"] == "API server set successfully"
+            assert response_data["apiServerId"] == 53285
+            assert response_data["apiServerUrl"] == "https://jp.authlete.com"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_set_api_server_invalid_id():
+    """Test set_api_server with invalid API server ID."""
+    from src.authlete_mcp.tools.utility_tools import set_api_server
+
+    mock_response = [{"id": 53285, "apiServerUrl": "https://jp.authlete.com", "description": "JP API Server"}]
+
+    with patch.dict(os.environ, {"ORGANIZATION_ACCESS_TOKEN": "test_token"}):
+        with patch(
+            "src.authlete_mcp.tools.utility_tools.make_authlete_idp_request", new_callable=AsyncMock
+        ) as mock_request:
+            mock_request.return_value = mock_response
+
+            result = await set_api_server("99999")
+
+            assert "API server with ID '99999' not found" in result
+            assert "Available API server IDs: 53285" in result
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_get_current_api_server_info_function():
+    """Test get_current_api_server_info function directly."""
+    from src.authlete_mcp.tools.utility_tools import get_current_api_server_info
+
+    # Test when no API server is configured
+    config.clear_current_api_server()
+    result = await get_current_api_server_info()
+
+    assert "No API server is currently configured" in result
+
+    # Test when API server is configured
+    config.set_current_api_server(12345, "https://api.example.com", "Test Server")
+    result = await get_current_api_server_info()
+
+    response_data = json.loads(result)
+    assert response_data["message"] == "Current API server configuration"
+    assert response_data["apiServerId"] == 12345
+    assert response_data["apiServerUrl"] == "https://api.example.com"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_create_service_with_configured_server():
+    """Test create_service function with pre-configured API server."""
+    from src.authlete_mcp.tools.service_tools import create_service
+
+    # Pre-configure API server
+    config.set_current_api_server(53285, "https://jp.authlete.com", "JP API Server")
+
+    # Mock service creation response
+    mock_service_response = {"service": {"number": 123456, "serviceName": "Test Service", "apiKey": 987654321}}
+
+    with patch.dict(os.environ, {"ORGANIZATION_ACCESS_TOKEN": "test_token", "ORGANIZATION_ID": "12345"}):
+        with patch(
+            "src.authlete_mcp.tools.service_tools.make_authlete_idp_request", new_callable=AsyncMock
+        ) as mock_request:
+            mock_request.return_value = mock_service_response
+
+            result = await create_service("Test Service", "Test Description")
+
+            assert "Error:" not in result
+            response_data = json.loads(result)
+            assert response_data["service"]["serviceName"] == "Test Service"

--- a/tests/test_patch_operations.py
+++ b/tests/test_patch_operations.py
@@ -136,6 +136,9 @@ async def test_patch_client_integration():
         async with ClientSession(read_stream, write_stream) as session:
             await session.initialize()
 
+            # Set API server to jp.authlete.com (ID: 53285)
+            await session.call_tool("set_api_server", {"apiServerId": "53285"})
+
             try:
                 # 1. Create test service
                 service_result = await session.call_tool(
@@ -273,6 +276,9 @@ async def test_patch_service_integration():
     async with stdio_client(server_params) as (read_stream, write_stream):
         async with ClientSession(read_stream, write_stream) as session:
             await session.initialize()
+
+            # Set API server to jp.authlete.com (ID: 53285)
+            await session.call_tool("set_api_server", {"apiServerId": "53285"})
 
             try:
                 # 1. Create test service

--- a/tests/test_service_deletion.py
+++ b/tests/test_service_deletion.py
@@ -29,6 +29,9 @@ async def test_delete_service_with_real_credentials():
         async with ClientSession(read_stream, write_stream) as session:
             await session.initialize()
 
+            # Set API server to jp.authlete.com (ID: 53285)
+            await session.call_tool("set_api_server", {"apiServerId": "53285"})
+
             # まずサービスを作成
             create_result = await session.call_tool(
                 "create_service", {"name": "pytest-deletion-test", "description": "Pytest deletion test service"}
@@ -46,7 +49,9 @@ async def test_delete_service_with_real_credentials():
                 service_id = str(service_data.get("apiKey"))
 
                 # 削除を試行
-                delete_result = await session.call_tool("delete_service", {"service_id": service_id})
+                delete_result = await session.call_tool(
+                    "delete_service", {"service_id": service_id, "apiServerId": "53285"}
+                )
 
                 assert delete_result.content
                 delete_response = delete_result.content[0].text

--- a/tests/test_service_operations.py
+++ b/tests/test_service_operations.py
@@ -56,6 +56,16 @@ async def test_create_service():
         async with ClientSession(read_stream, write_stream) as session:
             await session.initialize()
 
+            # Set API server to jp.authlete.com (ID: 53285)
+            set_result = await session.call_tool("set_api_server", {"apiServerId": "53285"})
+
+            assert set_result.content
+            set_response = set_result.content[0].text
+
+            # If API server setting fails due to invalid credentials, skip the test
+            if "Error" in set_response and ("Unknown user" in set_response or "invalid access token" in set_response):
+                pytest.skip("Invalid access token - skipping integration test")
+
             result = await session.call_tool(
                 "create_service", {"name": "pytest-test-service", "description": "Test service created by pytest"}
             )


### PR DESCRIPTION
## Summary
- ensure service tools honour explicit apiServerId overrides and fall back to configured defaults
- add async tests covering env precedence, manual overrides, and failure scenarios
- document optional nature of AUTHLETE_API_SERVER_ID / AUTHLETE_API_URL defaults in README

## Testing
- uv run pytest tests/test_api_server_selection.py
- uv run pytest tests/test_client_operations.py::test_client_secret_operations_with_service_api_key tests/test_client_operations.py::test_client_deletion_with_service_api_key tests/test_patch_operations.py::test_patch_client_integration tests/test_patch_operations.py::test_patch_service_integration
